### PR TITLE
Fix outdated stake commands

### DIFF
--- a/src/content/docs/operator/nocturne/node-running-guide.md
+++ b/src/content/docs/operator/nocturne/node-running-guide.md
@@ -117,7 +117,7 @@ It is best to wait until your node is synced up. You can find the latest block h
 
 The final step is to stake. You can stake by running:
 ```sh
-rusk-wallet stake --amt 1000 # Or however much you want to stake
+rusk-wallet moonlight-stake --amt 1000 # Or however much you want to stake
 ```
 
 Once the transaction has gone through, you can view your staking information by running:

--- a/src/content/docs/operator/nocturne/upgrade-node.md
+++ b/src/content/docs/operator/nocturne/upgrade-node.md
@@ -75,5 +75,5 @@ If you already have DUSK staked, wait until the chain starts producing blocks. Y
 
 6. Stake your nDUSK:
 ```sh
-rusk-wallet stake --amt 1000 # Or however much you want to stake
+rusk-wallet moonlight-stake --amt 1000 # Or however much you want to stake
 ```

--- a/src/content/docs/operator/node-setup/manual-resync.md
+++ b/src/content/docs/operator/node-setup/manual-resync.md
@@ -21,10 +21,14 @@ If your node is confirmed to be stuck (e.g. at block 50636) or significantly beh
 
 ### 1. Unstake (if applicable)
 
-If you are staked, the first step is to unstake to prevent any potential loss of stake due to node downtime:
+If you are staked, the first step is to unstake to prevent any potential loss of stake due to node downtime. Choose one:
 
 ```sh
-rusk-wallet unstake
+rusk-wallet moonlight-unstake
+```
+Or
+```sh
+rusk-wallet phoenix-unstake
 ```
 
 ### 2. Stop the Rusk Service
@@ -62,11 +66,16 @@ ruskquery block-height
 
 ### 6. Restake (if applicable)
 
-Once your node is close to the current block height, you can restake your DUSK tokens:
+Once your node is close to the current block height, you can restake your DUSK tokens. Choose one:
 
 ```sh
-rusk-wallet stake <amount>
+rusk-wallet moonlight-stake <amount>
 ```
+or
+```sh
+rusk-wallet phoenix-stake <amount>
+```
+
 Replace `<amount>` with the number of DUSK tokens you wish to stake.
 
 ## Conclusion


### PR DESCRIPTION
I'm assuming these docs are only valid for Nocturne at the moment and that the source of funds are from the faucet. So the commands prefer moonlight.