### PR TITLE
First contract minor fixes

### DIFF
--- a/src/content/docs/developer/smart-contract/guides/01-my-first-contract.md
+++ b/src/content/docs/developer/smart-contract/guides/01-my-first-contract.md
@@ -109,7 +109,7 @@ We also need a method to read the counter value, so our `Counter` methods implem
 
 ```rust
 impl Counter {
-    pub fn read_value(&self) -> i64 {
+    pub fn read_value(&self) -> u32 {
         self.value
     }
 

--- a/src/content/docs/developer/smart-contract/guides/02-compiling.md
+++ b/src/content/docs/developer/smart-contract/guides/02-compiling.md
@@ -34,7 +34,7 @@ Make sure that you use version ``1.75.0-nightly`` of rustc. This can be achieved
 ```toml
 // rust-toolchain.toml
 [toolchain]
-channel = "nightly-2023-11-10"
+channel = "nightly-2023-11-10" # 1.75.0-nightly
 targets = ["wasm32-unknown-unknown"]
 components = ["rust-src", "rustfmt", "cargo", "clippy"]
 ```
@@ -54,7 +54,7 @@ rustup target add wasm32-unknown-unknown
 You can pass a target flag to the cargo build command, to explicitly set the target you want to compile to. This command compiles the Rust project to WebAssembly in release mode, optimizing the output for performance.
 
 ```bash title="Terminal"
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32-unknown-unknown --release -Znext-lockfile-bump
 ```
 
 :::tip[Note]


### PR DESCRIPTION
* Fix read_value return type (from i64 to u32) 
* Add the flag -Znext-lockfile-bump for compiling the SC otherwise cargo complains with the following error:

```
sydh@sydh:~/dev/perso/dusk_network/my-first-contract$ cargo --version
cargo 1.75.0-nightly (7046d992f 2023-11-08)
sydh@sydh:~/dev/perso/dusk_network/my-first-contract$ cargo build --target wasm32-unknown-unknown --release
error: failed to parse lock file at: /home/sydh/dev/perso/dusk_network/my-first-contract/Cargo.lock

Caused by:
  lock file version 4 requires `-Znext-lockfile-bump`
```

Also I was thinking about adding a section to deploy the SC using rusk-wallet (instead of dusk-deploy-cli).

On testnet, I've tried the following command:

```
cargo run --release -- -n testnet -p dusk_p1 contract-deploy -c /home/sydh/dev/perso/dusk_network/my-first-contract/target/wasm32-unknown-unknown/release/my_first_contract.wasm --deploy-nonce 2 -p 2000 -l 506286400
    Finished release [optimized] target(s) in 0.14s
     Running `/home/sydh/dev/perso/dusk_network/rusk/target/release/rusk-wallet -n testnet -p 'dusk_p1' contract-deploy -c /home/sydh/dev/perso/dusk_network/my-first-contract/target/wasm32-unknown-unknown/release/my_first_contract.wasm --deploy-nonce 2 -p 2000 -l 506286400`
✔ Please enter wallet password: · [hidden]
2024-10-26T11:34:42.396948Z  INFO rusk_wallet::io::status: status="Opening notes database"
2024-10-26T11:34:42.411258Z  INFO rusk_wallet::io::status: status="Fetching account-data..."
2024-10-26T11:34:42.701375Z  INFO rusk_wallet::io::status: status="account-data received!"
2024-10-26T11:34:42.701400Z  INFO rusk_wallet::io::status: status="Fetching chain_id..."
2024-10-26T11:34:43.725219Z  INFO rusk_wallet::io::status: status="Chain id received!"
2024-10-26T11:34:43.733871Z  INFO rusk_wallet::io::status: status="Attempt to preverify tx..."
2024-10-26T11:34:46.608984Z  INFO rusk_wallet::io::status: status="Preverify success!"
2024-10-26T11:34:46.609011Z  INFO rusk_wallet::io::status: status="Propagating tx..."
2024-10-26T11:34:48.240465Z  INFO rusk_wallet::io::status: status="Transaction propagated!"
2024-10-26T11:34:48.499926Z  INFO rusk_wallet::io::status: status="Waiting for tx to be included into a block..."
2024-10-26T11:34:49.761170Z  INFO rusk_wallet::io::status: status="Waiting for tx to be included into a block..."
2024-10-26T11:34:51.711532Z  INFO rusk_wallet::io::status: status="Waiting for tx to be included into a block..."
2024-10-26T11:34:53.964293Z  INFO rusk_wallet::io::status: status="Waiting for tx to be included into a block..."
2024-10-26T11:34:55.602170Z  INFO rusk_wallet::io::status: status="Waiting for tx to be included into a block..."
2024-10-26T11:34:57.547514Z  INFO rusk_wallet::io::status: status="Waiting for tx to be included into a block..."
2024-10-26T11:34:59.493037Z  INFO rusk_wallet::io::status: status="Waiting for tx to be included into a block..."
2024-10-26T11:35:00.824358Z  INFO rusk_wallet::io::status: status="Waiting for tx to be included into a block..."
2024-10-26T11:35:02.503571Z  INFO rusk_wallet::io::status: status="Waiting for tx to be included into a block..."
Transaction error: Panic: failed deployment: Panic("Argument should correctly deserialize: ContextError(ArchiveError(OutOfBounds { base: 0x100820, offset: -4, range: 0x100820..0x100820 }))")
``` 

Let me know if I should open an issue on rusk repo and if adding a section to deploy with rusk-wallet would be accepted? :)