### PR TITLE
fix: document missing block event (reverted) in RUES

### DIFF
--- a/src/content/docs/developer/integrations/rues.md
+++ b/src/content/docs/developer/integrations/rues.md
@@ -287,10 +287,11 @@ a9909cd1...580a0000
 
 #### Block Events
 
-**Endpoint**: `/on/blocks:[block-hash]/[topic]`, where `[topic]` is optional. Block events can have the topic `accepted`, or `statechange`.
+**Endpoint**: `/on/blocks:[block-hash]/[topic]`, where `[topic]` is optional. Block events can have the topic `accepted, `statechange`, or `reverted`.
 
 - **accepted**: Indicates that a block has been accepted into the chain.
 - **statechange**: Represents a change in the state of a block. The state of a block can be either `finalized` or `confirmed`.
+- **reverted**: Indicates that a block has been removed from the chain because it got reverted during consensus.
 
 **Method**: `GET`
 


### PR DESCRIPTION
The source can be seen here: https://github.com/dusk-network/rusk/blob/539cf2b47363495b74ff860791b62cfcebf46029/node-data/src/events/blocks.rs#L60-L63