### PR TITLE
Add market infrastructure, Connect and llm content

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,0 +1,133 @@
+# Dusk Docs Full Context
+
+This file summarizes the public Dusk documentation for AI assistants, search systems, and readers that need a compact map of the docs.
+
+## Positioning
+
+Dusk is infrastructure for regulated digital assets and general finance. It is designed for workflows where issuers, venues, institutions, developers, and users need privacy, access controls, deterministic settlement, and selective disclosure.
+
+Dusk should be understood as a stack:
+
+- DuskDS: the Dusk L1 for consensus, settlement, data availability, native transaction models, and native execution.
+- DuskEVM: an OP Stack-based EVM execution environment using DUSK as gas and DuskDS for settlement/data availability.
+- DuskVM: the WASM execution environment for native Dusk smart contracts.
+- Rusk: the Rust node implementation that runs DuskDS.
+- Citadel: identity and access primitives for selective disclosure and regulated workflows.
+- Dusk Connect: wallet discovery and account connection for Dusk applications.
+- Dusk Trade: application-layer market infrastructure for tokenized financial assets.
+
+## Key Concepts
+
+### Regulated Market Workflows
+
+Dusk is designed for workflows such as:
+
+- regulated securities issuance
+- investor onboarding and eligibility checks
+- wallet binding and access controls
+- secondary market transfers
+- payment and settlement coordination
+- servicing, reporting, corporate actions, and selective disclosure
+
+Relevant docs:
+
+- https://docs.dusk.network/learn/market-infrastructure/
+- https://docs.dusk.network/learn/tokenization-comparison/
+- https://docs.dusk.network/learn/deep-dive/assets-and-regulations/
+
+### Privacy with Selective Disclosure
+
+Dusk supports confidential shielded transfers, public account flows, and selective disclosure patterns. The point is not to make every workflow hidden or every workflow public. Builders can decide which data should be public, which data should remain confidential, and which data should be disclosed to authorized parties.
+
+Relevant docs:
+
+- https://docs.dusk.network/learn/cryptography/
+- https://docs.dusk.network/learn/deep-dive/duskds-tx-models/
+- https://docs.dusk.network/developer/digital-identity/protocol/
+
+### Transaction Models
+
+DuskDS supports:
+
+- Moonlight: transparent public account flows.
+- Phoenix: confidential shielded transfers.
+
+Relevant docs:
+
+- https://docs.dusk.network/learn/deep-dive/duskds-tx-models/
+- https://docs.dusk.network/learn/web-wallet/
+
+### Execution Paths
+
+Dusk has two main developer paths:
+
+- DuskEVM: Solidity, EVM tooling, EVM wallets, Ethereum-compatible infrastructure.
+- Native Dusk: Rust/WASM contracts through DuskVM for protocol-level assets, custom execution, privacy, or zero-knowledge capabilities close to the settlement layer.
+
+Relevant docs:
+
+- https://docs.dusk.network/developer/overview/
+- https://docs.dusk.network/learn/deep-dive/dusk-evm/
+- https://docs.dusk.network/learn/deep-dive/dusk-vm/
+- https://docs.dusk.network/developer/smart-contracts-dusk-evm/deploy-on-evm/
+- https://docs.dusk.network/developer/smart-contracts-duskds/
+
+## Important Pages
+
+### Learn
+
+- Overview: https://docs.dusk.network/learn/overview/
+- Market Infrastructure: https://docs.dusk.network/learn/market-infrastructure/
+- Core Components: https://docs.dusk.network/learn/core-components/
+- Core Values: https://docs.dusk.network/learn/core-values/
+- Native Issuance: https://docs.dusk.network/learn/tokenization-comparison/
+- Ecosystem & Partners: https://docs.dusk.network/learn/ecosystem/
+- Tokenomics: https://docs.dusk.network/learn/tokenomics/
+- Glossary: https://docs.dusk.network/learn/glossary/
+
+### Developer
+
+- Developer Overview: https://docs.dusk.network/developer/overview/
+- Deploy on DuskEVM: https://docs.dusk.network/developer/smart-contracts-dusk-evm/deploy-on-evm/
+- Smart Contracts on DuskDS: https://docs.dusk.network/developer/smart-contracts-duskds/
+- Dusk Connect: https://docs.dusk.network/developer/integrations/dusk-connect/
+- Transaction Lifecycle: https://docs.dusk.network/developer/integrations/tx-lifecycle/
+- HTTP API: https://docs.dusk.network/developer/integrations/http-api/
+- W3sper SDK: https://docs.dusk.network/developer/integrations/w3sper/
+- Exchange Integration: https://docs.dusk.network/developer/integrations/exchanges/
+- Encoding & Hashing: https://docs.dusk.network/developer/integrations/reference/
+- Dusk Improvement Proposals: https://docs.dusk.network/developer/contribute/dips/
+- Grants: https://docs.dusk.network/developer/contribute/grants/
+
+### Operators
+
+- Operator Overview: https://docs.dusk.network/operator/overview/
+- Provisioner Node: https://docs.dusk.network/operator/provisioner/
+- Archive Node: https://docs.dusk.network/operator/archive-node/
+- Prover Node: https://docs.dusk.network/operator/prover/
+- Networks: https://docs.dusk.network/operator/networks/
+- Maintenance & Monitoring: https://docs.dusk.network/operator/maintenance-monitoring/
+- Troubleshooting: https://docs.dusk.network/operator/troubleshooting/
+
+### User Tools
+
+- Web Wallet: https://docs.dusk.network/learn/web-wallet/
+- Rusk Wallet: https://docs.dusk.network/learn/rusk-wallet/
+- Block Explorer: https://docs.dusk.network/learn/block-explorer/
+- Staking: https://docs.dusk.network/learn/guides/staking-basics/
+- DuskEVM Bridge: https://docs.dusk.network/learn/guides/duskevm-bridge/
+
+## Naming Guidance
+
+Use:
+
+- Dusk for the network/protocol/stack in general contexts.
+- DuskDS for the Dusk L1, settlement, consensus, data availability, and native transaction models.
+- DuskEVM for the EVM execution layer.
+- DuskVM for native WASM smart contract execution.
+- Moonlight for public account flows.
+- Phoenix for shielded transfer flows.
+- Privacy with selective disclosure for regulated privacy patterns.
+- Access controls for eligibility, wallet binding, and transfer-rule patterns.
+
+Avoid using “permissioned” to describe Dusk itself. If discussing restricted asset workflows, prefer “access-controlled”, “regulated”, or “eligible participant” unless specifically contrasting with closed permissioned systems.

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -32,6 +32,7 @@ Dusk is designed for workflows such as:
 Relevant docs:
 
 - https://docs.dusk.network/learn/market-infrastructure/
+- https://docs.dusk.network/learn/dusk-trade/
 - https://docs.dusk.network/learn/tokenization-comparison/
 - https://docs.dusk.network/learn/deep-dive/assets-and-regulations/
 
@@ -78,6 +79,7 @@ Relevant docs:
 
 - Overview: https://docs.dusk.network/learn/overview/
 - Market Infrastructure: https://docs.dusk.network/learn/market-infrastructure/
+- Dusk Trade: https://docs.dusk.network/learn/dusk-trade/
 - Core Components: https://docs.dusk.network/learn/core-components/
 - Core Values: https://docs.dusk.network/learn/core-values/
 - Native Issuance: https://docs.dusk.network/learn/tokenization-comparison/

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -62,7 +62,7 @@ Relevant docs:
 Dusk has two main developer paths:
 
 - DuskEVM: Solidity, EVM tooling, EVM wallets, Ethereum-compatible infrastructure.
-- Native Dusk: Rust/WASM contracts through DuskVM for protocol-level assets, custom execution, privacy, or zero-knowledge capabilities close to the settlement layer.
+- Native Dusk: general-purpose Rust/WASM contracts through DuskVM for protocol-level assets, native transaction models, custom execution, market logic, privacy, or zero-knowledge capabilities close to the settlement layer.
 
 Relevant docs:
 
@@ -91,6 +91,7 @@ Relevant docs:
 - Deploy on DuskEVM: https://docs.dusk.network/developer/smart-contracts-dusk-evm/deploy-on-evm/
 - Smart Contracts on DuskDS: https://docs.dusk.network/developer/smart-contracts-duskds/
 - Dusk Connect: https://docs.dusk.network/developer/integrations/dusk-connect/
+- Dusk Wallet Extension: https://docs.dusk.network/developer/integrations/wallet-extension/
 - Transaction Lifecycle: https://docs.dusk.network/developer/integrations/tx-lifecycle/
 - HTTP API: https://docs.dusk.network/developer/integrations/http-api/
 - W3sper SDK: https://docs.dusk.network/developer/integrations/w3sper/

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -16,6 +16,7 @@
 - [Deploy on DuskEVM](https://docs.dusk.network/developer/smart-contracts-dusk-evm/deploy-on-evm/): deploy Solidity contracts on DuskEVM.
 - [Smart Contracts on DuskDS](https://docs.dusk.network/developer/smart-contracts-duskds/): write Rust/WASM contracts for native Dusk execution.
 - [Dusk Connect](https://docs.dusk.network/developer/integrations/dusk-connect/): integrate wallet discovery and account connection.
+- [Dusk Wallet Extension](https://docs.dusk.network/developer/integrations/wallet-extension/): integrate with the first-party browser wallet provider.
 - [Transaction Lifecycle](https://docs.dusk.network/developer/integrations/tx-lifecycle/): understand transaction flow.
 - [HTTP API](https://docs.dusk.network/developer/integrations/http-api/): integrate with Dusk APIs.
 - [W3sper SDK](https://docs.dusk.network/developer/integrations/w3sper/): SDK integration.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,6 +6,7 @@
 
 - [Overview](https://docs.dusk.network/learn/overview/): high-level introduction to Dusk.
 - [Market Infrastructure](https://docs.dusk.network/learn/market-infrastructure/): how Dusk supports regulated asset workflows.
+- [Dusk Trade](https://docs.dusk.network/learn/dusk-trade/): product layer for tokenized financial asset workflows on Dusk.
 - [Core Components](https://docs.dusk.network/learn/core-components/): DuskDS, Rusk, DuskVM, DuskEVM, Citadel, and application-layer tooling.
 - [Core Values](https://docs.dusk.network/learn/core-values/): regulated workflows, access controls, selective disclosure, and deterministic settlement.
 - [Native Issuance](https://docs.dusk.network/learn/tokenization-comparison/): digitization, tokenization, and native issuance.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,40 @@
+# Dusk Docs
+
+> Dusk is infrastructure for regulated digital assets and general finance. The docs explain how to build, integrate, and operate on Dusk across DuskDS, DuskEVM, DuskVM, Dusk Connect, Citadel, wallets, APIs, and node operations.
+
+## Start Here
+
+- [Overview](https://docs.dusk.network/learn/overview/): high-level introduction to Dusk.
+- [Market Infrastructure](https://docs.dusk.network/learn/market-infrastructure/): how Dusk supports regulated asset workflows.
+- [Core Components](https://docs.dusk.network/learn/core-components/): DuskDS, Rusk, DuskVM, DuskEVM, Citadel, and application-layer tooling.
+- [Core Values](https://docs.dusk.network/learn/core-values/): regulated workflows, access controls, selective disclosure, and deterministic settlement.
+- [Native Issuance](https://docs.dusk.network/learn/tokenization-comparison/): digitization, tokenization, and native issuance.
+
+## Developer Docs
+
+- [Build on Dusk](https://docs.dusk.network/developer/overview/): choose between DuskEVM and native Dusk development.
+- [Deploy on DuskEVM](https://docs.dusk.network/developer/smart-contracts-dusk-evm/deploy-on-evm/): deploy Solidity contracts on DuskEVM.
+- [Smart Contracts on DuskDS](https://docs.dusk.network/developer/smart-contracts-duskds/): write Rust/WASM contracts for native Dusk execution.
+- [Dusk Connect](https://docs.dusk.network/developer/integrations/dusk-connect/): integrate wallet discovery and account connection.
+- [Transaction Lifecycle](https://docs.dusk.network/developer/integrations/tx-lifecycle/): understand transaction flow.
+- [HTTP API](https://docs.dusk.network/developer/integrations/http-api/): integrate with Dusk APIs.
+- [W3sper SDK](https://docs.dusk.network/developer/integrations/w3sper/): SDK integration.
+
+## Learn
+
+- [Transaction Models](https://docs.dusk.network/learn/deep-dive/duskds-tx-models/): Moonlight public accounts and Phoenix shielded transfers.
+- [DuskEVM](https://docs.dusk.network/learn/deep-dive/dusk-evm/): OP Stack-based EVM execution on Dusk.
+- [DuskVM](https://docs.dusk.network/learn/deep-dive/dusk-vm/): WASM execution for native Dusk contracts.
+- [Assets & Regulations](https://docs.dusk.network/learn/deep-dive/assets-and-regulations/): regulated asset workflow concepts.
+- [Cryptography](https://docs.dusk.network/learn/cryptography/): zero-knowledge proofs and cryptographic building blocks.
+
+## Operators and Tools
+
+- [Operator Overview](https://docs.dusk.network/operator/overview/): run and maintain Dusk infrastructure.
+- [Provisioner Node](https://docs.dusk.network/operator/provisioner/): run a provisioner node.
+- [Web Wallet](https://docs.dusk.network/learn/web-wallet/): use Dusk in the browser.
+- [Block Explorer](https://docs.dusk.network/learn/block-explorer/): inspect public network data.
+
+## Full Context
+
+- [llms-full.txt](https://docs.dusk.network/llms-full.txt): expanded index and terminology for LLM retrieval.

--- a/src/content/docs/developer/integrations/dusk-connect.md
+++ b/src/content/docs/developer/integrations/dusk-connect.md
@@ -42,6 +42,7 @@ The Dusk Connect SDK is developed in the Dusk Network GitHub organization:
 
 ## Read next
 
+- [Dusk Wallet Extension](/developer/integrations/wallet-extension)
 - [Web Wallet](/learn/web-wallet)
 - [Transaction Lifecycle](/developer/integrations/tx-lifecycle)
 - [W3sper SDK](/developer/integrations/w3sper)

--- a/src/content/docs/developer/integrations/dusk-connect.md
+++ b/src/content/docs/developer/integrations/dusk-connect.md
@@ -22,6 +22,8 @@ Dusk applications often need two kinds of integration:
 
 Dusk Connect is for the wallet side. For network APIs and transaction flow, see [Transaction Lifecycle](/developer/integrations/tx-lifecycle), [HTTP API](/developer/integrations/http-api), and [W3sper SDK](/developer/integrations/w3sper).
 
+If you are testing against the first-party browser wallet, use the [Dusk Wallet Extension](/developer/integrations/wallet-extension) as one compatible provider.
+
 ## Typical flow
 
 A dApp integration usually follows this shape:

--- a/src/content/docs/developer/integrations/dusk-connect.md
+++ b/src/content/docs/developer/integrations/dusk-connect.md
@@ -1,0 +1,47 @@
+---
+title: Dusk Connect
+description: Integrate Dusk wallet discovery and account connection into applications.
+---
+
+Dusk Connect is the wallet integration layer for Dusk applications. It gives dApps a consistent way to discover compatible wallets, request accounts, and build connection flows around Dusk accounts.
+
+Use Dusk Connect when your application needs to:
+
+- detect compatible Dusk wallet providers
+- let users select a wallet
+- request account access
+- handle public and shielded account flows in a consistent UI
+- integrate with Dusk wallet software without hardcoding one provider
+
+## Where it fits
+
+Dusk applications often need two kinds of integration:
+
+- **Network integration**: read chain data, submit transactions, and observe events.
+- **Wallet integration**: ask a user to connect an account and approve actions.
+
+Dusk Connect is for the wallet side. For network APIs and transaction flow, see [Transaction Lifecycle](/developer/integrations/tx-lifecycle), [HTTP API](/developer/integrations/http-api), and [W3sper SDK](/developer/integrations/w3sper).
+
+## Typical flow
+
+A dApp integration usually follows this shape:
+
+1. Discover available Dusk wallet providers.
+2. Show the user the compatible wallets.
+3. Request account access from the selected wallet.
+4. Store the active account and provider for the session.
+5. Ask the wallet to approve transactions or account actions when needed.
+
+The exact API depends on the version of Dusk Connect you integrate.
+
+## Repository
+
+The Dusk Connect SDK is developed in the Dusk Network GitHub organization:
+
+- <a href="https://github.com/dusk-network/connect" target="_blank" rel="noreferrer">dusk-network/connect</a>
+
+## Read next
+
+- [Web Wallet](/learn/web-wallet)
+- [Transaction Lifecycle](/developer/integrations/tx-lifecycle)
+- [W3sper SDK](/developer/integrations/w3sper)

--- a/src/content/docs/developer/integrations/wallet-extension.md
+++ b/src/content/docs/developer/integrations/wallet-extension.md
@@ -28,6 +28,8 @@ A typical dApp flow is:
 
 See [Dusk Connect](/developer/integrations/dusk-connect) for the SDK-level integration path.
 
+If you are building the application side, start with Dusk Connect. If you are testing or documenting the wallet-provider side, use this page together with the wallet provider API.
+
 ## Provider discovery
 
 The extension announces an EIP-1193-style provider through Dusk discovery events. Dusk is not an EVM chain, so wallet methods use Dusk-specific names.

--- a/src/content/docs/developer/integrations/wallet-extension.md
+++ b/src/content/docs/developer/integrations/wallet-extension.md
@@ -1,0 +1,89 @@
+---
+title: Dusk Wallet Extension
+description: Use the Dusk Wallet browser extension as a first-party wallet for Dusk applications.
+---
+
+The Dusk Wallet extension is the first-party browser wallet for Dusk. It gives users a self-custodial wallet in Chrome and Firefox, and gives applications a provider surface for connecting Dusk accounts.
+
+Use the extension when you need:
+
+- a browser wallet for Dusk accounts
+- public and shielded account flows
+- mainnet, testnet, devnet, or custom node support
+- dApp connection through Dusk provider discovery
+- a first-party wallet to test Dusk Connect integrations
+
+For users who only need a hosted browser wallet, see [Web Wallet](/learn/web-wallet). For terminal and operator workflows, see [Rusk Wallet](/learn/rusk-wallet).
+
+## How it fits with Dusk Connect
+
+Dusk Connect is the SDK layer for wallet discovery and account connection. The Dusk Wallet extension is one wallet provider that can be discovered through that flow.
+
+A typical dApp flow is:
+
+1. Use Dusk Connect or provider discovery to find available Dusk wallets.
+2. Let the user choose the Dusk Wallet extension.
+3. Request account access.
+4. Ask the wallet to approve account actions or transactions when needed.
+
+See [Dusk Connect](/developer/integrations/dusk-connect) for the SDK-level integration path.
+
+## Provider discovery
+
+The extension announces an EIP-1193-style provider through Dusk discovery events. Dusk is not an EVM chain, so wallet methods use Dusk-specific names.
+
+```js
+const providers = [];
+
+window.addEventListener("dusk:announceProvider", (event) => {
+  providers.push(event.detail);
+});
+
+window.dispatchEvent(new Event("dusk:requestProvider"));
+
+const dusk = providers[0]?.provider;
+const [account] = await dusk.request({ method: "dusk_requestAccounts" });
+
+dusk.on("accountsChanged", console.log);
+dusk.on("chainChanged", console.log);
+```
+
+For the canonical provider API, see the wallet repository:
+
+- <a href="https://github.com/dusk-network/wallet/blob/main/docs/provider-api.md" target="_blank" rel="noreferrer">Dusk Wallet provider API</a>
+
+## Install for development
+
+The extension builds Chrome and Firefox targets from the same repository.
+
+```bash
+git clone https://github.com/dusk-network/wallet
+cd wallet
+npm install
+```
+
+For Chrome:
+
+```bash
+npm run build:chrome
+```
+
+Then load `dist/` as an unpacked extension in `chrome://extensions` with Developer mode enabled.
+
+For Firefox:
+
+```bash
+npm run build:firefox
+```
+
+Then load `dist-firefox/` as a temporary add-on in `about:debugging`.
+
+## Repository
+
+- <a href="https://github.com/dusk-network/wallet" target="_blank" rel="noreferrer">dusk-network/wallet</a>
+
+## Read next
+
+- [Dusk Connect](/developer/integrations/dusk-connect)
+- [Transaction Lifecycle](/developer/integrations/tx-lifecycle)
+- [Web Wallet](/learn/web-wallet)

--- a/src/content/docs/developer/overview.mdx
+++ b/src/content/docs/developer/overview.mdx
@@ -1,32 +1,32 @@
 ---
 title: Build on Dusk
-description: Choose between DuskEVM and DuskDS and start building on Dusk.
+description: Choose between DuskEVM and native Dusk development and start building on Dusk.
 ---
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-Dusk has a **modular architecture** with:
+Dusk has a **modular architecture** for regulated digital assets, privacy-aware applications, and deterministic settlement:
 
-- **DuskDS** – the settlement and data layer (consensus, data availability, native transaction models, protocol contracts, DuskVM).
-- **DuskEVM** – the EVM execution layer where most smart contracts and dApps live.
+- **DuskDS** – the Dusk L1: settlement, consensus, data availability, native transaction models, protocol contracts, and DuskVM.
+- **DuskEVM** – the EVM execution layer for Solidity applications and familiar EVM tooling.
 
-As a builder you usually:
+As a builder, choose the path based on what your product needs:
 
-- write and deploy contracts on **DuskEVM**, and
-- rely on DuskDS for finality, privacy and settlement under the hood.
+- use **DuskEVM** when your application benefits from Solidity, EVM tooling, existing wallets, and Ethereum-compatible infrastructure.
+- use **native Dusk** when your application needs protocol-level assets, custom execution, privacy, or zero-knowledge capabilities close to the settlement layer.
 
 ## Choose your path
 
 <CardGrid>
   <LinkCard
-    title="Smart Contracts on DuskEVM (recommended)"
+    title="Smart Contracts on DuskEVM"
     href="/developer/smart-contracts-dusk-evm/deploy-on-evm"
     description="Deploy Solidity or Vyper contracts on DuskEVM using familiar EVM tooling."
   />
   <LinkCard
-    title="Smart Contracts on DuskDS (advanced)"
+    title="Native Dusk smart contracts"
     href="/developer/smart-contracts-duskds"
-    description="Write Rust/WASM contracts directly on the DuskDS settlement layer."
+    description="Write Rust/WASM contracts directly on Dusk when your application needs native execution."
   />
   <LinkCard
     title="Integrate with DuskDS"
@@ -42,33 +42,35 @@ As a builder you usually:
 
 ## When to use DuskEVM
 
-Use **DuskEVM** for almost all application‑level use cases:
+Use **DuskEVM** when your application is designed around the EVM ecosystem:
 
-- DeFi protocols, AMMs, lending, RWAs
-- NFTs and gaming
-- Apps that expect an EVM environment (tooling, libraries, infra)
+- tokenized asset applications
+- DeFi protocols, AMMs, and lending
+- applications that expect an EVM environment: tooling, libraries, wallets, and infrastructure
 
 You get:
 
 - Familiar languages and tooling (Solidity/Vyper, Hardhat/Foundry, etc.)
 - DUSK as the native gas token
-- Privacy & compliance features via the underlying DuskDS architecture and Hedger.
+- Settlement and data availability from DuskDS
+- A route toward confidential flows through Hedger where your application needs privacy
 
 See: [Smart Contracts on DuskEVM](/developer/smart-contracts-dusk-evm/deploy-on-evm).
 
-## When to use DuskDS contracts
+## When to use native Dusk contracts
 
-Use DuskDS smart contracts only when you need:
+Use native Dusk smart contracts when you need:
 
-- protocol‑level control on the settlement layer,
-- direct interaction with the DuskDS transaction models, or
-- specialised contracts that must run “next to” consensus.
+- protocol-level control on the settlement layer
+- direct interaction with Dusk transaction models
+- specialized contracts that need Rust/WASM execution
+- privacy or zero-knowledge capabilities that should live close to the base protocol
 
 Typical examples include:
 
-- genesis / protocol contracts (transfers, staking),
-- low‑level infrastructure contracts,
-- experiments that need direct access to the DuskDS VM and its unique features.
+- genesis or protocol contracts such as transfers and staking
+- low-level infrastructure contracts
+- applications that need direct access to DuskVM and native Dusk features
 
 If that’s you, start with:  
 [Smart Contracts on DuskDS](/developer/smart-contracts-duskds).

--- a/src/content/docs/developer/overview.mdx
+++ b/src/content/docs/developer/overview.mdx
@@ -10,10 +10,10 @@ Dusk has a **modular architecture** for regulated digital assets, privacy-aware 
 - **DuskDS** – the Dusk L1: settlement, consensus, data availability, native transaction models, protocol contracts, and DuskVM.
 - **DuskEVM** – the EVM execution layer for Solidity applications and familiar EVM tooling.
 
-As a builder, choose the path based on what your product needs:
+As a builder, choose the path based on what your product needs and which tooling model you want:
 
 - use **DuskEVM** when your application benefits from Solidity, EVM tooling, existing wallets, and Ethereum-compatible infrastructure.
-- use **native Dusk** when your application needs protocol-level assets, custom execution, privacy, or zero-knowledge capabilities close to the settlement layer.
+- use **native Dusk** when your application should build directly on Dusk's own execution model, native transaction models, Rust/WASM contracts, protocol-level assets, privacy, or zero-knowledge capabilities.
 
 ## Choose your path
 
@@ -26,7 +26,7 @@ As a builder, choose the path based on what your product needs:
   <LinkCard
     title="Native Dusk smart contracts"
     href="/developer/smart-contracts-duskds"
-    description="Write Rust/WASM contracts directly on Dusk when your application needs native execution."
+    description="Write general-purpose Rust/WASM contracts directly on Dusk's native execution layer."
   />
   <LinkCard
     title="Integrate with DuskDS"
@@ -59,18 +59,23 @@ See: [Smart Contracts on DuskEVM](/developer/smart-contracts-dusk-evm/deploy-on-
 
 ## When to use native Dusk contracts
 
-Use native Dusk smart contracts when you need:
+Native Dusk smart contracts are general-purpose smart contracts for Dusk's own execution environment. They are written in Rust, compiled to WASM, and executed by DuskVM.
+
+Use this path when you need:
 
 - protocol-level control on the settlement layer
 - direct interaction with Dusk transaction models
 - specialized contracts that need Rust/WASM execution
 - privacy or zero-knowledge capabilities that should live close to the base protocol
+- application logic that benefits from native Dusk assets, transaction models, or execution primitives
 
 Typical examples include:
 
 - genesis or protocol contracts such as transfers and staking
 - low-level infrastructure contracts
 - applications that need direct access to DuskVM and native Dusk features
+
+Compared with DuskEVM, native Dusk contracts require more familiarity with Dusk-specific tooling and architecture. The tradeoff is deeper access to the protocol's own model rather than compatibility with the broader EVM ecosystem.
 
 If that’s you, start with:  
 [Smart Contracts on DuskDS](/developer/smart-contracts-duskds).

--- a/src/content/docs/developer/smart-contracts-duskds.md
+++ b/src/content/docs/developer/smart-contracts-duskds.md
@@ -5,10 +5,12 @@ description: Build Rust/WASM smart contracts on DuskDS using the Forge framework
 
 Dusk offers two paths for smart contract development:
 
-- **DuskDS** (this page) - Rust/WASM contracts on Dusk's native settlement layer with access to privacy features and the full power of Rust's ecosystem
+- **DuskDS** (this page) - general-purpose Rust/WASM contracts on Dusk's native execution layer, with access to native transaction models, privacy-aware flows, and the full power of Rust's ecosystem
 - **[DuskEVM](/developer/smart-contracts-dusk-evm/deploy-on-evm)** - An Optimism-based EVM application layer for Solidity/Vyper contracts using familiar tooling (Hardhat, Foundry)
 
-Choose DuskDS for native integration with Dusk's privacy and settlement features. Choose DuskEVM for rapid prototyping or when porting existing Solidity contracts.
+Choose DuskDS when you want to build directly with Dusk's native primitives: Rust/WASM execution, protocol-level assets, custom market logic, public and shielded transaction models, or privacy-aware compliance flows. Choose DuskEVM when you want Solidity, EVM wallets, and the broader Ethereum tooling ecosystem.
+
+Native Dusk contracts are not limited to privacy-specific use cases. They can support general application logic, but they require developers to work closer to Dusk's own account, asset, and execution model than an EVM application would.
 
 ## Quick Start
 

--- a/src/content/docs/developer/smart-contracts-duskds.md
+++ b/src/content/docs/developer/smart-contracts-duskds.md
@@ -111,7 +111,7 @@ Events are emitted with `abi::emit("event_name", data)` and automatically includ
 
 Contracts have **two build targets** from the same source:
 
-1. **Contract WASM** (`make wasm`) - Runs on-chain in the Dusk VM
+1. **Contract WASM** (`make wasm`) - Runs on-chain in DuskVM
 2. **Data-driver WASM** (`make wasm-dd`) - Runs off-chain for JSON encoding/decoding
 
 The `contract` and `data-driver` features are **mutually exclusive**. See the [Forge README](https://github.com/dusk-network/forge/blob/main/README.md#cargotoml-configuration) for full Cargo.toml configuration.

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,18 +1,18 @@
 ---
-title: Welcome to Dusk! 
-description: The one-stop resource for the Dusk knowledge-base, including documentation, guides, tools and resources.
+title: Dusk Documentation
+description: Documentation for Dusk, infrastructure for regulated digital assets, privacy, and deterministic settlement.
 template: splash
 hero:
-  tagline: Welcome to the official documentation for the Dusk platform.
+  tagline: "Build, integrate, and operate on Dusk: institutional-grade infrastructure for regulated digital assets and general finance."
   image:
     light: ../../assets/hero-light.svg
     dark: ../../assets/hero-dark.svg
   actions:
-    - text: Read the docs 
+    - text: Start learning
       link: /learn/overview/
       icon: right-arrow
       variant: primary
-    - text: Visit our GitHub Page 
+    - text: GitHub
       link: https://github.com/dusk-network
       icon: external
 ---

--- a/src/content/docs/learn/core-components.md
+++ b/src/content/docs/learn/core-components.md
@@ -74,7 +74,7 @@ On top of the base protocol, Dusk supports application-layer protocols and tools
 
 ### Dusk Trade
 
-Dusk Trade is the application layer for tokenized financial assets on Dusk. It is being built around real market workflows: investor onboarding, wallet binding, controlled transfers, payment coordination, and compliant settlement.
+[Dusk Trade](/learn/dusk-trade) is the application layer for tokenized financial assets on Dusk. It is being built around real market workflows: investor onboarding, wallet binding, controlled transfers, payment coordination, and compliant settlement.
 
 ### Zedger / Hedger
 

--- a/src/content/docs/learn/core-components.md
+++ b/src/content/docs/learn/core-components.md
@@ -1,15 +1,15 @@
 ---
 title: Core Components
-description: Introduction to the core components that power Dusk.
+description: Introduction to the core components that power Dusk as infrastructure for regulated digital assets.
 ---
 
-Dusk is a modular blockchain architecture built for regulated finance: privacy where it’s needed, transparency where it’s required.
+Dusk is a modular blockchain architecture built for regulated finance: privacy where it is needed, transparency where it is useful, and deterministic settlement where market workflows require it.
 
 At a high level:
 
 | Component | Role | Where to go next |
 |---|---|---|
-| **DuskDS** | Settlement, consensus, and data availability | [Transaction Models](/learn/deep-dive/duskds-tx-models), [Run a node](/operator/overview) |
+| **DuskDS** | Dusk L1: settlement, consensus, data availability, and native transaction models | [Transaction Models](/learn/deep-dive/duskds-tx-models), [Run a node](/operator/overview) |
 | **Rusk** | The Rust node implementation that runs DuskDS and exposes APIs | [HTTP API](/developer/integrations/http-api/), <a href="https://github.com/dusk-network/rusk/" target="_blank" rel="noreferrer">GitHub</a> |
 | **DuskVM** | WASM execution environment for native smart contracts | [DuskVM deep dive](/learn/deep-dive/dusk-vm/), [Smart Contracts on DuskDS](/developer/smart-contracts-duskds/) |
 | **DuskEVM** | OP Stack-based EVM execution environment | [DuskEVM deep dive](/learn/deep-dive/dusk-evm/), [Deploy on DuskEVM](/developer/smart-contracts-dusk-evm/deploy-on-evm/) |
@@ -17,11 +17,11 @@ At a high level:
 
 ## DuskDS
 
-DuskDS is the settlement, consensus, and data availability layer at the foundation of the Dusk architecture. It provides finality, security, and native bridging for execution environments built on top (including DuskEVM and DuskVM).
+DuskDS is the Dusk L1: the settlement, consensus, and data availability layer at the foundation of the Dusk architecture. It provides finality, security, native transaction models, and bridging for execution environments built on top, including DuskEVM and DuskVM.
 
 DuskDS includes Rusk (the node implementation), Succinct Attestation (PoS consensus), Kadcast (P2P networking), and the genesis contracts (stake + transfer).
 
-DuskDS supports two transaction models: **Moonlight** (public) and **Phoenix** (shielded). See: [Transaction Models on Dusk](/learn/deep-dive/duskds-tx-models/).
+DuskDS supports two transaction models: **Moonlight** for transparent public accounts and **Phoenix** for confidential shielded transfers. See: [Transaction Models on Dusk](/learn/deep-dive/duskds-tx-models/).
 
 ### Rusk
 
@@ -47,13 +47,13 @@ Moonlight is account-based and public. Phoenix is UTXO-based and shielded. Both 
 
 ## Execution environments
 
-Dusk supports multiple execution environments on top of DuskDS. Each environment can focus on a specific developer experience (WASM vs EVM) while inheriting settlement and data availability from DuskDS.
+Dusk supports multiple execution environments on top of DuskDS. Each environment can focus on a specific developer experience while inheriting settlement and data availability from the Dusk L1.
 
-### Dusk VM
-[Dusk VM](/learn/deep-dive/dusk-vm) is a WASM execution environment built around Wasmtime. It’s optimized for Dusk-native smart contracts and privacy-focused applications.
+### DuskVM
+[DuskVM](/learn/deep-dive/dusk-vm) is a WASM execution environment built around Wasmtime. It is optimized for Dusk-native smart contracts that need direct access to native assets, custom execution, privacy, or zero-knowledge capabilities.
 
-### Dusk EVM
-[Dusk EVM](/learn/deep-dive/dusk-evm) is an OP Stack-based EVM-equivalent execution environment. It lets you deploy Solidity contracts using standard EVM tooling while using DuskDS for settlement and data availability.
+### DuskEVM
+[DuskEVM](/learn/deep-dive/dusk-evm) is an OP Stack-based EVM-equivalent execution environment. It lets you deploy Solidity contracts using standard EVM tooling while using DuskDS for settlement and data availability.
 
 ## Network Layer: Kadcast
 
@@ -70,7 +70,11 @@ For node operators: [Run a provisioner node](/operator/provisioner/).
 
 ## Applications
 
-On top of the base protocol, Dusk supports application-layer protocols for regulated markets.
+On top of the base protocol, Dusk supports application-layer protocols and tools for regulated markets.
+
+### Dusk Trade
+
+Dusk Trade is the application layer for tokenized financial assets on Dusk. It is being built around real market workflows: investor onboarding, wallet binding, controlled transfers, payment coordination, and compliant settlement.
 
 ### Zedger / Hedger
 

--- a/src/content/docs/learn/core-values.mdx
+++ b/src/content/docs/learn/core-values.mdx
@@ -1,40 +1,43 @@
 ---
 title: Core Values
-description: "What Dusk optimizes for: regulated markets, privacy with selective disclosure, and deterministic settlement."
+description: "What Dusk optimizes for: regulated markets, access controls, privacy with selective disclosure, and deterministic settlement."
 ---
 
-This page summarizes the principles behind Dusk and the tradeoffs they imply.
+This page summarizes the principles behind Dusk and the tradeoffs they imply for builders, operators, and market participants.
 If you’re new, start with [Overview](/learn/overview) and then read [Core Components](/learn/core-components).
 
 ## Principles
 
 ### Regulated workflows, on-chain
 
-Dusk is built for markets where rules are part of the product:
+Dusk is built for markets where rules are part of the workflow:
 
 - eligibility and access controls
 - disclosure and reporting requirements
 - constraints like limits, holds, and transfer restrictions
+- settlement rules that connect assets, payments, and participants
 
 ### Privacy with selective disclosure
 
 Dusk treats privacy as a protocol feature, not an application add-on:
 
-- confidential balances and transfers where needed
-- the ability to reveal information to authorized parties when required
+- confidential balances and shielded transfers where needed
+- public accounts and transparent flows where useful
+- the ability to reveal specific information to authorized parties when required
 
 For details, see [Cryptography](/learn/cryptography) and [Transaction Models](/learn/deep-dive/duskds-tx-models).
 
 ### Deterministic settlement
 
-Market infrastructure needs predictable finality. DuskDS is designed for fast, deterministic settlement suitable for regulated venues.
+Market infrastructure needs predictable finality. DuskDS is designed for fast, deterministic settlement suitable for regulated venues, payment workflows, and tokenized assets.
 
 ### Modular architecture
 
 Dusk separates settlement from execution so you can match the right environment to each use case:
 
-- DuskDS for consensus, settlement, and privacy-capable transaction models
+- DuskDS, the Dusk L1, for consensus, data availability, settlement, and native transaction models
 - DuskEVM for EVM-compatible application development
+- DuskVM for native Rust/WASM smart contracts on Dusk
 
 ## Vision
 

--- a/src/content/docs/learn/deep-dive/assets-and-regulations/index.md
+++ b/src/content/docs/learn/deep-dive/assets-and-regulations/index.md
@@ -1,13 +1,14 @@
 ---
 title: Assets & Regulations
-description: Background and references for regulated assets on Dusk.
+description: Background and implementation concepts for regulated assets on Dusk.
 ---
 
-This page is a short, docs-focused overview of common regulatory concepts that show up when building tokenized assets and other regulated flows.
+This page is a docs-focused overview of common regulatory and product concepts that show up when building tokenized assets, native issuance workflows, and other regulated financial applications on Dusk.
 
 If you're looking for implementation details, start here:
 - [Digital Identity Protocol (Citadel)](/developer/digital-identity/protocol)
 - [Transaction Models (Moonlight & Phoenix)](/learn/deep-dive/duskds-tx-models)
+- [Market Infrastructure on Dusk](/learn/market-infrastructure)
 
 ## MiCA (EU)
 
@@ -23,21 +24,64 @@ This is a technical overview for builders. For requirements and interpretation, 
 - ESMA’s MiCA hub: <a href="https://www.esma.europa.eu/esmas-activities/digital-finance-and-innovation/markets-crypto-assets-regulation-mica" target="_blank" rel="noreferrer">ESMA</a>
 - Legal text: <a href="https://eur-lex.europa.eu" target="_blank" rel="noreferrer">EUR-Lex</a>
 
-## Practical “Security Token” Lifecycle Requirements
+## Practical regulated asset requirements
 
 Regardless of jurisdiction, regulated assets often imply a few recurring product requirements:
+
 - **Access control**: only eligible parties can hold/transact (allowlists or identity/credential checks).
-- **Transfer checks**: transfers fail with clear reasons, and (ideally) can be simulated/checked pre-flight.
+- **Transfer checks**: transfers fail with clear reasons and can be simulated or checked before submission.
 - **Corporate actions**: dividends/coupons, burns, splits, and issuer-driven actions.
 - **Recovery & remediation**: processes for lost keys, fraud response, and legally required actions.
 - **Governance/voting**: snapshots and vote windows without double-counting.
 - **Audit & reporting**: the ability to produce compliant reports without leaking unnecessary user data.
+- **Settlement coordination**: asset and payment legs need to settle predictably.
 
 On Dusk, these concerns typically connect to identity/credentials (Citadel), smart contracts, and the dual transaction models (Moonlight for transparent flows and Phoenix for shielded flows).
+
+## Access controls
+
+Access controls answer questions such as:
+
+- Who is allowed to hold this asset?
+- Who is allowed to receive it?
+- Which transfers should fail?
+- Which rules apply to a venue, jurisdiction, or asset class?
+
+On Dusk, access-control patterns can be implemented with identity credentials, wallet binding, smart contract logic, and application-level checks. The exact design depends on the legal and product requirements of the asset.
+
+## Privacy with selective disclosure
+
+Regulated markets need privacy, but they also need evidence.
+
+Examples:
+
+- an investor should not expose every balance or transfer to every market participant
+- an issuer may need visibility into specific ownership or eligibility data
+- a supervisor, venue, or auditor may need controlled disclosure for a defined purpose
+
+Dusk’s privacy model supports this direction through shielded transfers, zero-knowledge proofs, and selective disclosure patterns.
+
+## Settlement and servicing
+
+Regulated assets usually require more than a transfer:
+
+- primary issuance
+- secondary market transfers
+- settlement against a payment leg
+- corporate actions
+- investor updates
+- reporting and audit trails
+
+DuskDS provides deterministic finality and native transaction models. Applications can use DuskEVM or native Dusk contracts depending on whether the workflow needs EVM compatibility, native execution, or closer integration with Dusk’s transaction models.
 
 ## Dematerialization and CSDs (Concepts)
 
 Dematerialization is the shift from paper certificates to electronic records of ownership. In traditional finance, Central Securities Depositories (CSDs) and associated market infrastructure manage issuance, custody, and settlement processes.
 
-For many tokenization projects, the relevant takeaway is that “real-world” asset workflows often require more than transfers: role-based controls, recovery paths, and auditability tend to be first-class requirements.
+For many tokenization projects, the relevant takeaway is that “real-world” asset workflows often require more than transfers: role-based controls, recovery paths, servicing, reporting, and auditability tend to be first-class requirements.
 
+## Read next
+
+- [Native Issuance](/learn/tokenization-comparison)
+- [Market Infrastructure on Dusk](/learn/market-infrastructure)
+- [Digital Identity Protocol](/developer/digital-identity/protocol)

--- a/src/content/docs/learn/deep-dive/assets-and-regulations/index.md
+++ b/src/content/docs/learn/deep-dive/assets-and-regulations/index.md
@@ -9,6 +9,7 @@ If you're looking for implementation details, start here:
 - [Digital Identity Protocol (Citadel)](/developer/digital-identity/protocol)
 - [Transaction Models (Moonlight & Phoenix)](/learn/deep-dive/duskds-tx-models)
 - [Market Infrastructure on Dusk](/learn/market-infrastructure)
+- [Dusk Trade](/learn/dusk-trade)
 
 ## MiCA (EU)
 
@@ -82,6 +83,7 @@ For many tokenization projects, the relevant takeaway is that “real-world” a
 
 ## Read next
 
+- [Dusk Trade](/learn/dusk-trade)
 - [Native Issuance](/learn/tokenization-comparison)
 - [Market Infrastructure on Dusk](/learn/market-infrastructure)
 - [Digital Identity Protocol](/developer/digital-identity/protocol)

--- a/src/content/docs/learn/deep-dive/dusk-evm.md
+++ b/src/content/docs/learn/deep-dive/dusk-evm.md
@@ -7,7 +7,7 @@ DuskEVM is an EVM-equivalent execution environment built on the OP Stack that us
 
 Use DuskEVM when your application benefits from Solidity, Ethereum-compatible tooling, EVM wallets, and existing smart contract infrastructure.
 
-Use native Dusk development instead when your application needs Rust/WASM execution, direct access to native Dusk transaction models, or protocol-level privacy and zero-knowledge capabilities. For that path, see [DuskVM](/learn/deep-dive/dusk-vm/) and [Smart Contracts on DuskDS](/developer/smart-contracts-duskds/).
+Use native Dusk development instead when your application should be built directly against Dusk's own execution model: Rust/WASM contracts, native transaction models, protocol-level assets, custom market logic, or privacy and zero-knowledge capabilities. For that path, see [DuskVM](/learn/deep-dive/dusk-vm/) and [Smart Contracts on DuskDS](/developer/smart-contracts-duskds/).
 
 ## Where DuskEVM fits
 

--- a/src/content/docs/learn/deep-dive/dusk-evm.md
+++ b/src/content/docs/learn/deep-dive/dusk-evm.md
@@ -5,8 +5,20 @@ description: DuskEVM is an OP Stack-based EVM execution environment that uses Du
 
 DuskEVM is an EVM-equivalent execution environment built on the OP Stack that uses DuskDS for settlement and data availability.
 
-Use DuskEVM when you want to deploy Solidity contracts and use standard EVM tooling (wallets, explorers, Hardhat, Foundry).
-For Dusk-native smart contracts (WASM; Phoenix/Moonlight), see [DuskVM](/learn/deep-dive/dusk-vm/).
+Use DuskEVM when your application benefits from Solidity, Ethereum-compatible tooling, EVM wallets, and existing smart contract infrastructure.
+
+Use native Dusk development instead when your application needs Rust/WASM execution, direct access to native Dusk transaction models, or protocol-level privacy and zero-knowledge capabilities. For that path, see [DuskVM](/learn/deep-dive/dusk-vm/) and [Smart Contracts on DuskDS](/developer/smart-contracts-duskds/).
+
+## Where DuskEVM fits
+
+DuskEVM is the EVM execution path in the Dusk stack:
+
+- **Developers** use familiar Solidity tooling.
+- **Applications** can inherit settlement and data availability from DuskDS.
+- **Users** pay gas in DUSK on DuskEVM.
+- **Privacy-sensitive flows** can use additional Dusk tooling such as Hedger where appropriate.
+
+For the broader architecture, see [Core Components](/learn/core-components).
 
 ## Network Information
 

--- a/src/content/docs/learn/deep-dive/dusk-vm.md
+++ b/src/content/docs/learn/deep-dive/dusk-vm.md
@@ -6,20 +6,20 @@ description: Learn about DuskVM, the Wasmtime-based VM that executes native smar
 
 ## Overview
 
-[DuskVM](https://github.com/dusk-network/rusk/tree/master/vm) is the WASM virtual machine for native smart contracts on Dusk. It is based on the <a href="https://wasmtime.dev" target="_blank" rel="noreferrer">Wasmtime</a> runtime, with custom support for Dusk’s execution model.
+[DuskVM](https://github.com/dusk-network/rusk/tree/master/vm) is the WASM virtual machine for native smart contracts on Dusk. It is based on the <a href="https://wasmtime.dev" target="_blank" rel="noreferrer">Wasmtime</a> runtime, with custom support for Dusk's execution model.
 
-Use DuskVM when your application needs native Dusk execution: protocol-level assets, Rust/WASM contracts, custom execution, privacy, or zero-knowledge capabilities close to the settlement layer.
+Use DuskVM when your application should run as a native Dusk contract: protocol-level assets, Rust/WASM contracts, custom execution, market logic, privacy-aware flows, or zero-knowledge capabilities close to the settlement layer.
 
-Use DuskEVM instead when your application is designed around Solidity, EVM wallets, and Ethereum-compatible tooling. See [DuskEVM](/learn/deep-dive/dusk-evm).
+Use DuskEVM instead when your application is designed around Solidity, EVM wallets, and Ethereum-compatible tooling. DuskVM is closer to Dusk's native model; DuskEVM is closer to the Ethereum developer ecosystem. See [DuskEVM](/learn/deep-dive/dusk-evm).
 
 ## Where DuskVM fits
 
-DuskVM is part of the DuskDS layer. It is the native execution environment for smart contracts that should live close to the Dusk L1 transaction models and settlement layer.
+DuskVM is part of the DuskDS layer. It is the native execution environment for general-purpose smart contracts that should live close to Dusk's transaction models and settlement layer.
 
 At a high level, DuskVM provides:
 
 - Specific memory management mechanism
-- Support for Dusk’s ABI
+- Support for Dusk's ABI
 - Support for inter-contract calls 
 
 DuskVM functions as the host-side interface, handling the execution environment and system-level operations.

--- a/src/content/docs/learn/deep-dive/dusk-vm.md
+++ b/src/content/docs/learn/deep-dive/dusk-vm.md
@@ -1,24 +1,34 @@
 ---
 title: DuskVM
-
-description: Learn about Dusk VM, the wasmtime VM that efficiently executes smart contracts on Dusk.
+description: Learn about DuskVM, the Wasmtime-based VM that executes native smart contracts on Dusk.
 
 ---
 
-## Dusk VM
+## Overview
 
-<a href="https://github.com/dusk-network/rusk/tree/master/vm" target="_blank">Dusk VM</a> is the WASM virtual machine for running Dusk's smart contracts, and it is based on the <a href="https://wasmtime.dev" target="_blank">Wasmtime</a> runtime, with a few custom modifications:
+[DuskVM](https://github.com/dusk-network/rusk/tree/master/vm) is the WASM virtual machine for native smart contracts on Dusk. It is based on the <a href="https://wasmtime.dev" target="_blank" rel="noreferrer">Wasmtime</a> runtime, with custom support for Dusk’s execution model.
+
+Use DuskVM when your application needs native Dusk execution: protocol-level assets, Rust/WASM contracts, custom execution, privacy, or zero-knowledge capabilities close to the settlement layer.
+
+Use DuskEVM instead when your application is designed around Solidity, EVM wallets, and Ethereum-compatible tooling. See [DuskEVM](/learn/deep-dive/dusk-evm).
+
+## Where DuskVM fits
+
+DuskVM is part of the DuskDS layer. It is the native execution environment for smart contracts that should live close to the Dusk L1 transaction models and settlement layer.
+
+At a high level, DuskVM provides:
+
 - Specific memory management mechanism
 - Support for Dusk’s ABI
 - Support for inter-contract calls 
 
-Dusk VM functions as the host-side interface, handling the execution environment and system-level operations
+DuskVM functions as the host-side interface, handling the execution environment and system-level operations.
 
-##### Compiling contracts to WASM
+## Compiling contracts to WASM
 
-Dusk VM expects WASM as bytecode, meaning that smart contracts must be compiled into WASM bytecode in order for Dusk VM to execute them. Smart contracts are entirely responsible for validating their inputs, processing them according to the contract’s logic, and returning the appropriate outputs. This ensures that smart contracts operate predictably and securely within the standardized execution environment provided by the Dusk VM.
+DuskVM expects WASM as bytecode, meaning that smart contracts must be compiled into WASM bytecode in order for DuskVM to execute them. Smart contracts are entirely responsible for validating their inputs, processing them according to the contract’s logic, and returning the appropriate outputs. This ensures that smart contracts operate predictably and securely within the standardized execution environment provided by DuskVM.
 
-Contracts compiled to WASM can be executed by Dusk VM, with the following caveats:
+Contracts compiled to WASM can be executed by DuskVM, with the following caveats:
 - The contract needs to expose the "argument buffer" (`argbuf`), which is a special region of 64KB in the contract's memory
 - Each exposed function complies with the following calling convention: `fn foo(u32) -> u32`
 
@@ -26,4 +36,4 @@ The received u32 value indicates the length of the input data, which has been pl
 
 ## Dusk Core
 
-<a href="https://github.com/dusk-network/rusk/tree/master/core" target="_blank">Dusk Core</a> provides a lot of useful modules that can be used on the contract side to aid in development. It is the library that allows developers to create smart contracts directly on top of Dusk Core.
+<a href="https://github.com/dusk-network/rusk/tree/master/core" target="_blank" rel="noreferrer">Dusk Core</a> provides modules that can be used on the contract side to aid development. It is the library that allows developers to create smart contracts directly on top of Dusk Core.

--- a/src/content/docs/learn/dusk-trade.md
+++ b/src/content/docs/learn/dusk-trade.md
@@ -1,0 +1,58 @@
+---
+title: Dusk Trade
+description: Where Dusk Trade fits in the Dusk stack and how it turns market infrastructure into tokenized asset workflows.
+---
+
+Dusk Trade is the application layer for tokenized financial assets on Dusk.
+
+It sits above the base protocol and turns Dusk's market-infrastructure primitives into user-facing workflows: asset discovery, investor onboarding, wallet connection, payment coordination, trading actions, and settlement.
+
+## What Dusk Trade is for
+
+Dusk Trade is designed for regulated market workflows where assets are not just listed and transferred, but also need eligibility, disclosure, and settlement logic around them.
+
+Typical flows include:
+
+- discovering tokenized financial assets
+- connecting a wallet
+- completing onboarding or eligibility checks
+- buying or selling an asset
+- coordinating the asset leg and payment leg
+- exposing the right information to issuers, venues, investors, or other authorized parties
+
+## Where it fits in the stack
+
+Dusk Trade is not the base protocol. It is a product layer that can use the Dusk stack underneath it.
+
+| Layer | Role |
+| --- | --- |
+| **DuskDS** | Settlement, finality, data availability, native transaction models |
+| **DuskEVM** | EVM-compatible application execution and Solidity tooling |
+| **DuskVM** | Native Rust/WASM execution for Dusk-specific contracts |
+| **Citadel** | Identity, credentials, and selective disclosure patterns |
+| **Dusk Connect** | Wallet discovery and account connection |
+| **Dusk Wallet Extension** | First-party browser wallet provider for Dusk applications |
+
+The exact architecture depends on the product and regulatory requirements of the market being served.
+
+## Why it matters
+
+For regulated assets, the hard part is rarely a token contract in isolation. The hard part is the complete market workflow:
+
+- who can access the asset
+- who can hold or transfer it
+- what information is public
+- what information is confidential
+- what can be selectively disclosed
+- how payment and asset settlement are coordinated
+- how issuers, venues, and investors interact with the same environment
+
+Dusk Trade is where those requirements become a usable product surface.
+
+## Read next
+
+- [Market Infrastructure on Dusk](/learn/market-infrastructure)
+- [Native Issuance](/learn/tokenization-comparison)
+- [Assets & Regulations](/learn/deep-dive/assets-and-regulations)
+- [Dusk Connect](/developer/integrations/dusk-connect)
+- [Dusk Wallet Extension](/developer/integrations/wallet-extension)

--- a/src/content/docs/learn/guides/staking-basics.md
+++ b/src/content/docs/learn/guides/staking-basics.md
@@ -22,6 +22,8 @@ To earn protocol staking rewards directly, you run a provisioner node 24/7 and s
 - Run a node: [Provisioner node](/operator/provisioner)
 - Set up wallet + stake: [Wallet setup](/operator/guides/node-wallet-setup)
 
+If you are deciding whether to operate infrastructure yourself, read this page first, then move to the operator guide once you are ready to run a node.
+
 ### 2) Staking pools (no infrastructure)
 
 Some third-party services and on-chain pools stake on behalf of users. This can let you earn staking yield without running your own node, but it adds operator and smart contract risk.
@@ -80,5 +82,6 @@ If you withdraw down to **600 DUSK** active stake, the **400 DUSK** inactive sta
 ## Next steps
 
 - Direct staking (run your own node): [Provisioner node](/operator/provisioner), then [Wallet setup](/operator/guides/node-wallet-setup)
+- Operator maintenance after staking: [Maintenance & monitoring](/operator/maintenance-monitoring)
 - Understand rewards and emissions: [Tokenomics](/learn/tokenomics)
 - If you hold ERC20/BEP20 DUSK: [Mainnet migration](/learn/guides/mainnet-migration)

--- a/src/content/docs/learn/market-infrastructure.md
+++ b/src/content/docs/learn/market-infrastructure.md
@@ -1,0 +1,68 @@
+---
+title: Market Infrastructure on Dusk
+description: How Dusk supports regulated asset workflows from issuance to trading, disclosure, and settlement.
+---
+
+Dusk is designed for regulated digital asset workflows where the asset, participant permissions, privacy requirements, and settlement process need to coordinate around the same infrastructure.
+
+This page explains the market-infrastructure view of Dusk. For the protocol components underneath it, see [Core Components](/learn/core-components).
+
+## The workflow problem
+
+Regulated markets are rarely just “create a token and transfer it”.
+
+Real workflows usually involve:
+
+- issuers creating and servicing assets
+- venues coordinating primary or secondary market activity
+- investors proving eligibility
+- custodians or wallets controlling access to assets
+- payment legs that need to settle with the asset leg
+- reporting, disclosure, and supervision requirements
+
+When these steps live in separate systems, market participants need reconciliation, manual controls, and off-chain coordination.
+
+## What Dusk provides
+
+Dusk provides a shared base for market workflows that need both public coordination and protected data.
+
+| Need | Dusk capability |
+| --- | --- |
+| Participant eligibility | Identity, wallet binding, and access-control patterns |
+| Privacy | Phoenix shielded transfers and zero-knowledge proofs |
+| Transparency | Moonlight public accounts and public chain data |
+| Selective disclosure | Controlled visibility for issuers, venues, auditors, or supervisors |
+| Settlement | DuskDS finality and asset/payment coordination patterns |
+| EVM compatibility | DuskEVM for Solidity applications and existing EVM tooling |
+
+The goal is not to make every workflow private or every workflow public. The goal is to let builders choose what should be visible, what should be confidential, and what should be disclosed to specific parties.
+
+## Example workflow
+
+A regulated digital asset workflow on Dusk can be designed around:
+
+1. **Issuer setup**: define the asset, eligibility requirements, and lifecycle rules.
+2. **Investor onboarding**: bind wallets to verified participants or credentials.
+3. **Transfer controls**: enforce who can hold or transfer the asset.
+4. **Trading or distribution**: coordinate orders, transfers, and settlement conditions.
+5. **Settlement**: connect the asset leg and payment leg with deterministic finality.
+6. **Servicing and disclosure**: support reporting, corporate actions, and selective access to required information.
+
+Different applications can implement this differently. Dusk provides the protocol building blocks and execution paths.
+
+## Product fit
+
+Use the Dusk stack depending on the layer you are building:
+
+- **DuskDS** for settlement, data availability, native transaction models, and Dusk-native execution.
+- **DuskEVM** for Solidity applications, EVM tooling, and Ethereum-compatible developer workflows.
+- **DuskVM** for Rust/WASM contracts that need native Dusk execution.
+- **Citadel** for identity, credentials, and selective disclosure patterns.
+- **Dusk Connect** for wallet discovery and account connection in Dusk applications.
+
+## Read next
+
+- [Native Issuance](/learn/tokenization-comparison)
+- [Assets & Regulations](/learn/deep-dive/assets-and-regulations)
+- [Core Components](/learn/core-components)
+- [Build on Dusk](/developer/overview)

--- a/src/content/docs/learn/market-infrastructure.md
+++ b/src/content/docs/learn/market-infrastructure.md
@@ -59,9 +59,13 @@ Use the Dusk stack depending on the layer you are building:
 - **DuskVM** for Rust/WASM contracts that need native Dusk execution.
 - **Citadel** for identity, credentials, and selective disclosure patterns.
 - **Dusk Connect** for wallet discovery and account connection in Dusk applications.
+- **Dusk Trade** for product-level tokenized asset workflows such as onboarding, wallet connection, buying, selling, and settlement coordination.
+
+If you want to understand the product layer, start with [Dusk Trade](/learn/dusk-trade). If you want the underlying regulated asset concepts, read [Assets & Regulations](/learn/deep-dive/assets-and-regulations).
 
 ## Read next
 
+- [Dusk Trade](/learn/dusk-trade)
 - [Native Issuance](/learn/tokenization-comparison)
 - [Assets & Regulations](/learn/deep-dive/assets-and-regulations)
 - [Core Components](/learn/core-components)

--- a/src/content/docs/learn/overview.mdx
+++ b/src/content/docs/learn/overview.mdx
@@ -1,31 +1,31 @@
 ---
 title: About Dusk
-description: A blockchain for regulated markets that need privacy, compliance controls, and fast settlement.
+description: Institutional-grade infrastructure for regulated digital assets, privacy with selective disclosure, and deterministic settlement.
 
 ---
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
-Dusk is a blockchain designed for regulated finance: you can issue, trade, and settle assets on-chain without putting sensitive market data on public display.
+Dusk is infrastructure for regulated digital assets and general finance. It is designed for workflows where issuers, venues, institutions, developers, and users need privacy, access controls, and deterministic settlement without putting sensitive market data on public display.
 
 ## At a glance
 
-On Dusk you can build markets where:
+On Dusk you can build and operate workflows where:
 
-- **Institutions** can encode eligibility, disclosure, and reporting rules into on-chain workflows.
-- **Users** can use confidential balances and transfers (with the ability to reveal information to authorized parties when required).
-- **Developers** can ship dApps with familiar EVM tooling while relying on a settlement layer built for privacy and compliance.
+- **Institutions** can coordinate regulated asset workflows with eligibility, disclosure, reporting, and settlement rules.
+- **Users** can hold public balances, use shielded transfers, and disclose information selectively when a workflow requires it.
+- **Developers** can ship applications with familiar EVM tooling or build directly on Dusk when they need native assets, privacy, or zero-knowledge capabilities.
 
 ## What is Dusk?
 
-Most financial market infrastructure is still a patchwork of closed systems. Public blockchains remove platform risk, but fully transparent execution leaks positions, counterparties, and balances.
+Most financial market infrastructure is still a patchwork of closed systems. Public blockchains reduce platform dependency, but fully transparent execution can expose positions, counterparties, balances, and operational data that regulated markets cannot publish by default.
 
 Dusk is built to support regulated markets on-chain without forcing a choice between:
 
-- **Compliance** (KYC/AML checks, eligibility, limits, reporting, disclosure)
-- **Privacy** (confidential balances and transfers, selective disclosure)
-- **Settlement performance** (fast, deterministic finality)
+- **Access controls**: eligibility checks, limits, transfer restrictions, and wallet binding.
+- **Privacy with selective disclosure**: confidential transfers where needed, with controlled visibility for authorized parties.
+- **Settlement performance**: fast, deterministic finality for market workflows.
 
-In short: Dusk is a privacy-enabled, regulation-aware blockchain for institutional-grade finance.
+In short: Dusk is institutional-grade market infrastructure for on-chain finance.
 
 ## Why Dusk?
 
@@ -33,19 +33,21 @@ In short: Dusk is a privacy-enabled, regulation-aware blockchain for institution
 
 Dusk is designed around the needs of regulated financial institutions and venues:
 
-- Native support for compliant issuance of securities and RWAs  
-- Identity and permissioning primitives that let you differentiate between public and restricted flows  
-- On‑chain logic that can reflect real‑world obligations (eligibility, limits, reporting, etc.)
+- Regulated securities and real-world asset workflows
+- Identity and access primitives for public, restricted, and selectively disclosed flows
+- On-chain logic that can reflect real-world obligations: eligibility, limits, reporting, recovery, and settlement
 
 See: [Core Values](/learn/core-values) and [Tokenization & Native Issuance](/learn/tokenization-comparison).
 
+For the workflow view, see [Market Infrastructure on Dusk](/learn/market-infrastructure).
+
 ### Privacy by design, transparent when needed
 
-Dusk uses zero‑knowledge proofs and dual transaction models (Phoenix and Moonlight) to let you choose between:
+Dusk uses zero-knowledge proofs and dual transaction models to let you choose between:
 
-- Public transactions for transparent flows
-- Shielded transactions for confidential balances and transfers
-- Selective disclosure to authorized parties when required
+- **Moonlight** for transparent public account flows
+- **Phoenix** for confidential shielded transfers
+- **Selective disclosure** when authorized parties need evidence without exposing unnecessary data
 
 See: [Cryptography](/learn/cryptography) and [Transaction Models on Dusk](/learn/deep-dive/duskds-tx-models).
 
@@ -63,8 +65,9 @@ For the full consensus specification, see Section 3 “Consensus mechanism” of
 
 Dusk separates settlement from execution:
 
-- **DuskDS**: consensus, data availability, settlement, and the privacy-enabled transaction model
+- **DuskDS**: the Dusk L1 for consensus, data availability, settlement, and native transaction models
 - **DuskEVM**: an Ethereum-compatible execution layer where DUSK is the native gas token
+- **DuskVM**: the WASM execution environment for Dusk-native smart contracts
 
 Assets can move between layers so you can use the right environment for each job.
 
@@ -76,21 +79,21 @@ Some example use cases Dusk was designed for:
 
 **Regulated digital securities**
 - Tokenized equity, debt, or funds with embedded compliance rules  
-- On‑chain corporate actions and transparent yet privacy‑respecting cap tables
+- On-chain corporate actions and privacy-respecting ownership workflows
 
 **Institutional DeFi**
 - Lending, AMMs, and structured products that must enforce KYC/AML  
 - Separation of public market signals from private position details
 
-**Payment & settlement rails**
+**Payment & settlement infrastructure**
 - Confidential payments between institutions  
 - Delivery‑versus‑payment (DvP) settlement of tokenized assets
 
 **Self‑sovereign identity & access control**
-- Permissioned venues where access is controlled via verifiable credentials  
+- Regulated venues where access is controlled via verifiable credentials
 - Compliance checks enforced in smart contracts instead of manual back‑office processes
 
-For more inspiration, see [Dusk’s use cases](https://dusk.network/pages/usecases) and [Additional Resources](/learn/deep-dive/additional-resources).
+For more inspiration, see [Dusk’s use cases](https://dusk.network/use-cases/) and [Additional Resources](/learn/deep-dive/additional-resources).
 
 ## Architecture at a glance
 
@@ -98,10 +101,10 @@ Here’s how the main components fit together:
 
 | Component   | Role in the system                                                | Learn more                                   |
 | ---------- | ------------------------------------------------------------------ | ------------------------------------------- |
-| **DuskDS** | Settlement, consensus, data availability, and native transaction model | [Core Components](/learn/core-components)   |
+| **DuskDS** | Dusk L1: settlement, consensus, data availability, and native transaction models | [Core Components](/learn/core-components)   |
 | **DuskEVM**| EVM execution environment where DUSK is the gas token              | [Deploy on DuskEVM](/developer/smart-contracts-dusk-evm/deploy-on-evm) |
 | **Rusk**   | Reference node implementation that runs Succinct Attestation       | [Run a node](/operator/overview)            |
-| **Citadel**| Identity & access primitives for compliant, permissioned flows     | [Core Components](/learn/core-components#citadel) |
+| **Citadel**| Identity and access primitives for selective disclosure and regulated flows | [Core Components](/learn/core-components#citadel) |
 
 If you want a deeper technical dive, start with [Cryptography](/learn/cryptography) or the [Dusk Whitepaper](https://dusk-cms.ams3.digitaloceanspaces.com/Dusk_Whitepaper_2024_4db72f92a1.pdf).
 

--- a/src/content/docs/learn/tokenization-comparison.md
+++ b/src/content/docs/learn/tokenization-comparison.md
@@ -43,4 +43,4 @@ In practice, that means you can:
 - build applications and tokenization-style workflows with familiar EVM tooling through **DuskEVM**, and
 - rely on **DuskDS**, the Dusk L1, for privacy-capable transaction models, data availability, and deterministic finality.
 
-If you want the architectural overview next, see [Core Components](/learn/core-components). For the product and market framing, see [Overview](/learn/overview).
+If you want the architectural overview next, see [Core Components](/learn/core-components). For the product and market framing, see [Overview](/learn/overview), [Market Infrastructure on Dusk](/learn/market-infrastructure), and [Dusk Trade](/learn/dusk-trade).

--- a/src/content/docs/learn/tokenization-comparison.md
+++ b/src/content/docs/learn/tokenization-comparison.md
@@ -1,9 +1,9 @@
 ---
 title: Native Issuance
-description: What native issuance means, how it differs from tokenization, and why it matters for regulated assets.
+description: What native issuance means, how it differs from tokenization, and why it matters for regulated digital assets.
 ---
 
-People often use “tokenization” to mean “putting an asset on a blockchain”. For regulated assets, it helps to be more precise because the lifecycle (issuance, custody, trading, settlement, reporting) determines what has to happen off-chain.
+People often use “tokenization” to mean “putting an asset on a blockchain”. For regulated assets, it helps to be more precise because the lifecycle (issuance, custody, trading, settlement, disclosure, reporting) determines what still has to happen outside the ledger.
 
 This page defines the terms and explains where **native issuance** fits in.
 
@@ -19,7 +19,7 @@ Tokenization is issuing a token that represents an asset (or a claim on an asset
 
 ### Native issuance
 
-Native issuance means the asset itself is created and managed **on-chain**: issuance, transfers, and (depending on the design) settlement happen on the ledger without needing to reconcile a “token” against a separate system of record.
+Native issuance means the asset itself is created and managed **on-chain**: issuance, transfers, servicing, and settlement can happen around the ledger instead of using a token as a wrapper around a separate system of record.
 
 ### Digitization vs Tokenization vs Native Issuance
 Here’s a quick comparison:
@@ -27,20 +27,20 @@ Here’s a quick comparison:
 |                      | **Digitization**                                                      | **Tokenization**                                                    | **Native Issuance**                                                |
 |---------------------------------|----------------------------------------------------------------------|--------------------------------------------------------------------|--------------------------------------------------------------------|
 | **Definition**                  | Conversion of paper-based systems into a digital format                   | Creation of a synthetic asset representing an underlying asset | Assets created directly on-chain without needing an underlying asset |
-| **Functionality**               | Basic digital representation, no added functionality                  | Fractionalization and Programmability (Smart Contracts) | Full asset lifecycle on-chain with no reconciliation requirements  |
-| **Settlement Process**          | Relies on traditional systems like CSDs and clearinghouses             | Relies on traditional systems like CSDs and clearinghouses             | Instant on-chain settlement, no reliance on external systems        |
-| **Custody**                     | Custodial (assets held by third-party)                               | Custodial (underlying asset held by a third-party)                     | Non-custodial, asset exists fully on-chain                          |
-| **Efficiency**                  | Inefficient due to reliance on intermediaries and slow settlement      | Some efficiency improvements but still faces reconciliation delays and costs   | High efficiency with near-instant settlement and reduced costs   |
-| **Risk of Settlement Failure**   | Yes, due to manual reconciliation and intermediary involvement       | Yes, due to manual reconciliation and intermediary involvement                 | No, as settlement is on-chain                    |
-| **Innovation Level**            | Zero. This is how things work now                  | Low. It only introduces fractionalization and partial programmability              | High. It removes intermediaries and enables fully on-chain processes    |
+| **Functionality**               | Digital recordkeeping, often without changing the market workflow | Programmability around a representation of the asset | Asset lifecycle can be designed directly around on-chain workflows |
+| **Settlement Process**          | Relies on traditional systems like CSDs and clearinghouses | Often still relies on traditional systems or reconciliation | Settlement can happen on-chain with deterministic finality |
+| **Custody**                     | Usually custodial or registry-based | Often custodial because the underlying asset remains elsewhere | Can reduce reliance on separate custody and registry layers, depending on the legal structure |
+| **Efficiency**                  | Limited by existing intermediaries and settlement processes | Improves distribution and programmability, but may keep reconciliation overhead | Can reduce handoffs between issuance, transfer, servicing, and settlement |
+| **Operational Risk**            | Manual processes and reconciliation can create delays or errors | Reconciliation between token and underlying asset remains important | Fewer duplicated records when the asset workflow is natively on-chain |
+| **Innovation Level**            | Incremental operational improvement | Better distribution and composability | Market workflow redesign around issuance, access controls, disclosure, and settlement |
 
 ## Where Dusk fits
 
-Dusk is built for regulated markets where **privacy, compliance controls, and deterministic settlement** are requirements, not add-ons.
+Dusk is built for regulated markets where **access controls, privacy with selective disclosure, and deterministic settlement** are requirements, not add-ons.
 
 In practice, that means you can:
 
-- build applications and tokenization-style workflows with familiar EVM tooling (via **DuskEVM**), and
-- rely on the settlement layer (**DuskDS**) for privacy-capable transaction models and finality.
+- build applications and tokenization-style workflows with familiar EVM tooling through **DuskEVM**, and
+- rely on **DuskDS**, the Dusk L1, for privacy-capable transaction models, data availability, and deterministic finality.
 
 If you want the architectural overview next, see [Core Components](/learn/core-components). For the product and market framing, see [Overview](/learn/overview).

--- a/src/content/docs/operator/guides/node-wallet-setup.md
+++ b/src/content/docs/operator/guides/node-wallet-setup.md
@@ -11,6 +11,8 @@ You can use the node installer guide to [quickly launch your Provisioner node](/
 
 This guide explains setting up the wallet and the last steps needed to start running your node.
 
+For the staking model, maturity period, reward timing, and unstaking behavior, read [Staking on Dusk](/learn/guides/staking-basics) alongside this operator setup guide.
+
 ## Preparation
 
 ### Obtain a mnemonic

--- a/src/content/docs/operator/provisioner.mdx
+++ b/src/content/docs/operator/provisioner.mdx
@@ -7,7 +7,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Provisioners are full nodes that participate in consensus. To participate, you stake a **minimum of 1000 DUSK** and run a provisioner node 24/7.
 
-If you only want to stake (without operating infrastructure), start with: [Staking on Dusk](/learn/guides/staking-basics/).
+If you only want to stake or understand staking before operating infrastructure, start with: [Staking on Dusk](/learn/guides/staking-basics/).
 
 ## Provisioner Specifications
 
@@ -149,4 +149,4 @@ Now set up the node wallet and stake so you can participate in consensus.
 
 Follow: [Node wallet setup](/operator/guides/node-wallet-setup/).
 
-For next steps, see: [Maintenance & monitoring](/operator/maintenance-monitoring/) and [Upgrade your node](/operator/guides/upgrade-node/).
+For staking rules and reward timing, see [Staking on Dusk](/learn/guides/staking-basics/). For next steps after setup, see [Maintenance & monitoring](/operator/maintenance-monitoring/) and [Upgrade your node](/operator/guides/upgrade-node/).

--- a/src/sidebars/siteSidebar.js
+++ b/src/sidebars/siteSidebar.js
@@ -8,6 +8,7 @@ const siteSidebar = [
         collapsed: false,
         items: [
           { label: "Overview", link: "/learn/overview" },
+          { label: "Market Infrastructure", link: "/learn/market-infrastructure" },
           { label: "Core Components", link: "/learn/core-components" },
           { label: "Core Values", link: "/learn/core-values" },
           { label: "Native Issuance", link: "/learn/tokenization-comparison" },
@@ -61,6 +62,7 @@ const siteSidebar = [
           { label: "Smart Contracts on DuskDS", link: "/developer/smart-contracts-duskds" },
           { label: "Stake Abstraction", link: "/learn/hyperstaking" },
           { label: "Digital Identity Protocol", link: "/developer/digital-identity/protocol" },
+          { label: "Dusk Connect", link: "/developer/integrations/dusk-connect" },
         ],
       },
       {

--- a/src/sidebars/siteSidebar.js
+++ b/src/sidebars/siteSidebar.js
@@ -63,6 +63,7 @@ const siteSidebar = [
           { label: "Stake Abstraction", link: "/learn/hyperstaking" },
           { label: "Digital Identity Protocol", link: "/developer/digital-identity/protocol" },
           { label: "Dusk Connect", link: "/developer/integrations/dusk-connect" },
+          { label: "Dusk Wallet Extension", link: "/developer/integrations/wallet-extension" },
         ],
       },
       {

--- a/src/sidebars/siteSidebar.js
+++ b/src/sidebars/siteSidebar.js
@@ -9,6 +9,7 @@ const siteSidebar = [
         items: [
           { label: "Overview", link: "/learn/overview" },
           { label: "Market Infrastructure", link: "/learn/market-infrastructure" },
+          { label: "Dusk Trade", link: "/learn/dusk-trade" },
           { label: "Core Components", link: "/learn/core-components" },
           { label: "Core Values", link: "/learn/core-values" },
           { label: "Native Issuance", link: "/learn/tokenization-comparison" },


### PR DESCRIPTION
Updates the docs to better reflect Dusk’s positioning as market infrastructure for regulated digital assets.

Includes:
- Adds a market infrastructure overview page
- Adds a Dusk Connect integration page
- Adds a wallet extension page
- Adds a Dusk Trade page
- Reframes developer paths around DuskEVM and native Dusk without making either the default
- Updates core learn/developer pages with clearer institutional and tokenization language
- Adds `llms.txt` and `llms-full.txt` for AI/resource discovery
