### PR TITLE
Standardize practical guides and correct staking guidance

### DIFF
--- a/src/content/docs/developer/integrations/exchanges.md
+++ b/src/content/docs/developer/integrations/exchanges.md
@@ -81,7 +81,7 @@ The [multisig contract](https://github.com/dusk-network/multisig-contract) conta
 
 ## Token Migration (If Applicable)
 
-Users can migrate ERC20/BEP20 DUSK to native DUSK using the [migration contract](https://github.com/dusk-network/dusk-migration) and the [Web Wallet](https://apps.dusk.network/wallet/).
+Users can migrate ERC20/BEP20 DUSK to DUSK on Dusk mainnet using the [migration contract](https://github.com/dusk-network/dusk-migration) and the [Web Wallet](https://apps.dusk.network/wallet/).
 
 More information: [/learn/guides/mainnet-migration](/learn/guides/mainnet-migration).
 

--- a/src/content/docs/learn/guides/bep20-bridge.md
+++ b/src/content/docs/learn/guides/bep20-bridge.md
@@ -1,70 +1,71 @@
 ---
-title: Native DUSK to BEP20 Bridge
-description: How to bridge your native DUSK tokens to BEP20 DUSK on Binance Smart Chain.
+title: Bridge DUSK from Dusk mainnet to BSC
+description: Move DUSK from Dusk mainnet to BEP20 DUSK on BNB Smart Chain.
 ---
 
-This guide explains how to bridge **native DUSK** (Dusk mainnet) to **BEP20 DUSK** on Binance Smart Chain (BSC) using the [Web Wallet](https://apps.dusk.network/wallet/).
+Send DUSK to the official bridge account through the Web Wallet to receive BEP20 DUSK at a specified BNB Smart Chain (BSC) address.
 
-When bridging, your native DUSK tokens are locked on the Dusk network. Once locked, a mint operation is initiated on Binance Smart Chain, issuing an equivalent amount of BEP20 DUSK to your specified address. The full bridging process typically takes around one hour.
+## At a glance
 
-:::note
-Want to **bridge from BEP20 DUSK to native DUSK** instead? Check our [Migration Guide](/learn/guides/mainnet-migration/) for the complete walkthrough.
-:::
+| | |
+|---|---|
+| Direction | Dusk mainnet to BSC |
+| Interface | [Mainnet Web Wallet](https://apps.dusk.network/wallet/) |
+| Destination asset | BEP20 DUSK |
+| Typical time | Around one hour |
+| Cost | Dusk transaction fee plus a 1 DUSK bridge fee |
 
-## Who this is for
-
-- You have **native DUSK** on Dusk mainnet.
-- You want **BEP20 DUSK** in an EVM wallet on BSC.
-
-## What you need
-
-- Access to the [Web Wallet](https://apps.dusk.network/wallet/).
-- Enough native DUSK to cover the amount you want to bridge **plus** the bridge fee.
-- A **BSC EVM address** (starts with `0x...`) where you want to receive BEP20 DUSK.
+To move ERC20 or BEP20 DUSK in the other direction, use the [mainnet migration guide](/learn/guides/mainnet-migration/).
 
 :::caution
-The BSC address is provided in the **memo** field. If you omit the memo or provide an invalid address, the bridge will not know where to mint, and funds can be lost.
+The memo determines which BSC address receives the BEP20 DUSK. A missing or invalid memo cannot be processed automatically and may make the transfer unrecoverable.
 :::
 
-## Expected time and fees
+## Before you start
 
-- **Time**: typically around one hour.
-- **Fees**: the bridge charges a flat **1 DUSK** fee per transaction (your minted amount is `sent - 1 DUSK`).
+You need:
 
-## Steps
+- access to the [Web Wallet](https://apps.dusk.network/wallet/);
+- more than 1 DUSK, plus enough DUSK for the network transaction fee; and
+- a BSC address that you control, beginning with `0x`.
 
-1. Open the [Web Wallet](https://apps.dusk.network/wallet/).
-2. Open or import your Dusk wallet.
-3. Navigate to the **Send** tab.
-4. Enter the official **Bridge Address** as the recipient:
-```
-24jFms4JqYdWb19jFn3CUjNUQz1AeRozYnwsHuUkLbXAj2gRBq598aLAJmqmsaPcsCNJTgTaJTaUZCXpT3s9UeWBsHTmd5hQx95JymZSUsmtwoibiB8AMp4bZjAiLMjmAH3x
-```
-5. In the **Memo** field, enter your **BEP20 compatible address** (your BSC wallet address).
-6. Specify the amount of native DUSK to bridge. The minimum is 1.000000001 DUSK (just over 1 DUSK).
-7. Review and confirm the transaction.
+The bridge deducts 1 DUSK from the amount sent. The minimum useful transfer is therefore `1.000000001 DUSK`, which delivers `0.000000001 DUSK` on BSC.
 
-Your DUSK will be locked on the Dusk network, and an equivalent amount will be minted on BSC shortly after.
+## Bridge your DUSK
 
-## FAQ
+1. Open the [Web Wallet](https://apps.dusk.network/wallet/), unlock your wallet, and open **Send**.
+2. Enter the official BSC bridge account as the recipient:
 
-**How long does the bridge process take?**  
-Typically around one hour. Network congestion and confirmation times can affect the timing.
+   ```text
+   24jFms4JqYdWb19jFn3CUjNUQz1AeRozYnwsHuUkLbXAj2gRBq598aLAJmqmsaPcsCNJTgTaJTaUZCXpT3s9UeWBsHTmd5hQx95JymZSUsmtwoibiB8AMp4bZjAiLMjmAH3x
+   ```
 
-**Where do the BEP20 tokens go?**  
-They are sent to the EVM address specified in the memo field.
+3. In **Memo**, enter the BSC address where you want to receive BEP20 DUSK.
+4. Enter an amount greater than 1 DUSK.
+5. On the review screen, compare the full bridge account and memo address with the values you intended, then send the transaction.
 
-**What happens if I omit the memo or use an invalid address?**  
-The bridge will ignore your transaction, and funds will not be bridged. This means your funds would be lost. Always double-check the memo field before confirming.
+The Web Wallet detects the bridge account and requires an EVM-formatted memo, but you remain responsible for checking that the destination address is yours.
 
-**Can I use this bridge for ERC20 DUSK?**  
-No. This bridge only supports native DUSK to **BEP20 DUSK** on Binance Smart Chain.
+## Verify the bridge
 
-**Is there a fee?**  
-Yes, the bridge charges a flat fee of 1 DUSK per transaction. Your bridged amount will be **original amount - 1 DUSK**.
+First confirm that the transfer succeeded in the [Dusk mainnet explorer](https://apps.dusk.network/explorer/). The BEP20 DUSK should then appear at the memo address on BSC. The amount received is the amount sent minus the 1 DUSK bridge fee.
+
+Processing normally takes around one hour. Network or operator conditions can extend that time.
 
 ## Troubleshooting
 
-- **Nothing arrived on BSC after around one hour**: confirm your Dusk transfer succeeded and double-check the memo contains the correct `0x...` address.
-- **I used the wrong memo address**: the bridge can’t mint to an unknown target. This is usually not reversible.
-- **I bridged to an exchange address**: only do this if the exchange explicitly supports BEP20 DUSK deposits and you’re sure the memo address is correct.
+**Nothing arrived after around one hour**
+
+Confirm that the Dusk transaction succeeded and that its memo contains the intended BSC address. Retain the Dusk transaction hash when seeking support.
+
+**The amount sent was 1 DUSK or less**
+
+No BSC payout is expected because the amount does not exceed the 1 DUSK bridge fee.
+
+**The memo is missing or incorrect**
+
+The transfer cannot be routed automatically. Do not submit another transfer until you have checked the first transaction and its memo.
+
+**The destination is an exchange address**
+
+Only bridge directly to an exchange when it explicitly supports BEP20 DUSK deposits to that exact address. Otherwise, use a self-custodial BSC wallet.

--- a/src/content/docs/learn/guides/duskevm-bridge.md
+++ b/src/content/docs/learn/guides/duskevm-bridge.md
@@ -1,34 +1,39 @@
 ---
 title: Bridge DUSK between Dusk L1 and DuskEVM Testnet
-description: Use the Dusk Web Wallet to move testnet DUSK between the Dusk L1 and DuskEVM.
+description: Move testnet DUSK between the Dusk L1 and DuskEVM through the Web Wallet.
 ---
 
-The Dusk bridge moves DUSK between the Dusk L1 and DuskEVM while keeping one asset across both environments. On DuskEVM, the bridged DUSK is available in your EVM account and is used to pay gas.
+The DuskEVM bridge keeps DUSK as the native asset on both sides. DUSK deposited into DuskEVM is available in the connected EVM account and pays DuskEVM gas.
 
-The current bridge interface labels the Dusk L1 side **DuskDS**. This guide uses **Dusk L1** for the network layer and **DuskDS** only when referring to that on-screen label.
+The bridge interface labels the Dusk L1 side **DuskDS**. This guide uses **Dusk L1** for the network and **DuskDS** only for that on-screen label.
 
-This guide uses testnet DUSK, which has no real-world value, and the testnet Web Wallet.
+:::note
+This guide uses testnet DUSK, which has no real-world value.
+:::
+
+## At a glance
+
+| | |
+|---|---|
+| Network | DuskEVM Testnet; testnet DUSK only |
+| Deposit actions | Submit on Dusk L1, then wait for the DuskEVM balance |
+| Withdrawal actions | Initiate on DuskEVM, then prove and finalize on Dusk L1 |
+| Readiness | Follow **Withdrawal status** in the Web Wallet |
+| Fees | Source transaction fee, plus two Dusk L1 fees for withdrawal proof and finalization |
+
+Withdrawal readiness depends on published network state, proof maturity, and dispute-game checks. The Web Wallet status is authoritative; do not calculate readiness from elapsed time alone.
 
 ## Before you start
 
 You need:
 
-- a Dusk Web Wallet account with unshielded testnet DUSK for deposits and withdrawal actions on the Dusk L1;
-- an EVM wallet, such as MetaMask, that supports adding a custom network; and
-- enough DUSK in the source account to cover the bridge amount and its transaction fee.
+- a Dusk account with enough unshielded testnet DUSK for the transfer and any Dusk L1 actions;
+- an EVM wallet, such as MetaMask, that supports custom networks; and
+- enough DUSK on the source side to cover the amount and transaction fee.
 
-Request DUSK from the [testnet faucet](/operator/networks#how-to-get-testnet-tokens), then unshield the amount you want to bridge.
+Request DUSK from the [testnet faucet](/operator/networks#how-to-get-testnet-tokens), then unshield the amount needed for Dusk L1 bridge actions.
 
-## Deposit into DuskEVM
-
-### 1. Open the bridge
-
-1. Open the [testnet Web Wallet](https://apps.testnet.dusk.network/wallet/) and unlock your account.
-2. Go to `Dashboard -> Bridge`.
-3. Connect your EVM wallet.
-4. Approve adding or switching to DuskEVM Testnet when your EVM wallet asks.
-
-Your wallet should be connected to:
+The Web Wallet should add or select this network:
 
 | Setting | Value |
 |---|---|
@@ -37,90 +42,76 @@ Your wallet should be connected to:
 | RPC | `https://rpc.testnet.evm.dusk.network` |
 | Currency symbol | `DUSK` |
 
-### 2. Configure the transfer
+## Deposit into DuskEVM
 
-Set:
+1. Open the [testnet Web Wallet](https://apps.testnet.dusk.network/wallet/) and unlock your Dusk account.
+2. Go to `Dashboard -> Bridge` and connect your EVM wallet.
+3. Approve adding or switching to DuskEVM Testnet when your EVM wallet asks.
+4. Set **From** to **DuskDS**, **To** to **DuskEVM**, and enter the amount.
+5. Check the full destination address selected in your EVM wallet, then review and send the Dusk L1 transaction.
 
-- **From:** DuskDS (Dusk L1)
-- **To:** DuskEVM
-- **Amount:** the amount of testnet DUSK to deposit
+Keep the transaction hash until the deposit is visible on DuskEVM.
 
-The destination is the address currently selected in your connected EVM wallet. Check the full address before continuing; an EVM transaction cannot correct a deposit sent to the wrong account.
+### Verify the deposit
 
-### 3. Review and send
+Confirm the originating transaction in the [Dusk testnet explorer](https://apps.testnet.dusk.network/explorer/). Once the deposit is processed, check the connected account in your EVM wallet or the [DuskEVM testnet explorer](https://explorer.testnet.evm.dusk.network/).
 
-On the review screen, confirm:
-
-- the displayed direction is DuskDS to DuskEVM;
-- the Dusk L1 source account and EVM destination are correct;
-- the amount and fee are acceptable.
-
-Send the transaction and keep the status screen open until the wallet has recorded it. The originating transaction can also be inspected in the [Dusk testnet explorer](https://apps.testnet.dusk.network/explorer/).
-
-### 4. Confirm the deposit
-
-After the deposit is processed, the balance of the connected EVM account increases on DuskEVM Testnet. Check it in your EVM wallet or search for the address in the [DuskEVM testnet explorer](https://explorer.testnet.evm.dusk.network/).
-
-The Dusk L1 transaction and the resulting DuskEVM credit happen on different layers, so they do not necessarily appear at the same moment.
+The Dusk L1 transaction and DuskEVM credit occur on different layers and may not appear at the same time.
 
 ## Withdraw to Dusk L1
 
-A withdrawal returns DUSK from your EVM account to the Dusk L1. Unlike a deposit, it requires three on-chain actions: initiate the withdrawal on DuskEVM, prove it on the Dusk L1, and finalize it on the Dusk L1.
+A withdrawal requires three on-chain actions: initiate it on DuskEVM, prove it on the Dusk L1, and finalize it on the Dusk L1.
 
-### 1. Submit the withdrawal
+### 1. Initiate the withdrawal
 
 1. Open `Dashboard -> Bridge` in the testnet Web Wallet.
 2. Connect the EVM wallet that holds the DUSK.
-3. Set **From** to DuskEVM and **To** to DuskDS.
-4. Enter the amount, review the destination Dusk L1 account, and send.
+3. Set **From** to **DuskEVM** and **To** to **DuskDS**.
+4. Enter the amount, check the destination Dusk account, and send.
 
-The first transaction is submitted on DuskEVM. Keep enough DUSK in the EVM account to pay its gas fee, and retain the withdrawal transaction hash.
+Keep enough DUSK in the EVM account for gas and retain the DuskEVM transaction hash.
 
-### 2. Check the withdrawal status
+### 2. Check its status
 
-Open **Withdrawal status** from the bridge. The latest withdrawal made in the current browser is filled in automatically. Otherwise, paste the DuskEVM withdrawal transaction hash and select **Check status**.
+Open **Withdrawal status**. The Web Wallet fills in the latest withdrawal from the current browser when available; otherwise, paste the DuskEVM transaction hash and select **Check status**.
 
-The first status is normally **Waiting for output proposal**. No action is required until the network has published an output that covers the withdrawal.
+The first status is normally **Waiting for output proposal**. No action is required until it changes to **Ready to prove**.
 
 ### 3. Prove on Dusk L1
 
-When the status changes to **Ready to prove**, select **Prove withdrawal** and confirm the Dusk L1 transaction in the Web Wallet.
+When the status is **Ready to prove**, select **Prove withdrawal** and confirm the Dusk L1 transaction.
 
-After the proof is submitted, the status changes to **Waiting to finalize** while the proof maturity delay and dispute-game checks complete.
-
-:::note
-Proof and finalization readiness are determined by network state, not by a timer alone. Use **Check status** rather than calculating readiness from elapsed time.
-:::
+After the proof is submitted, the status moves through **Proof submitted** and **Waiting to finalize** while the required checks complete.
 
 ### 4. Finalize on Dusk L1
 
-When the status changes to **Ready to finalize**, select **Finalize withdrawal** and confirm the Dusk L1 transaction that releases the DUSK to your Dusk account.
+When the status is **Ready to finalize**, select **Finalize withdrawal** and confirm the Dusk L1 transaction that releases the DUSK.
 
-Proving and finalizing are separate Dusk L1 transactions. Keep enough unshielded DUSK on the Dusk L1 to pay both fees. After finalization is confirmed, the returned amount appears in the destination account.
+Keep enough unshielded DUSK on the Dusk L1 to pay for both the proof and finalization transactions. The returned amount appears in the destination account after finalization confirms.
 
 ## Troubleshooting
 
 **The EVM wallet shows the wrong network**
 
-Switch to DuskEVM Testnet and confirm that the chain ID is `745` before retrying.
+Switch to DuskEVM Testnet and confirm that the chain ID is `745`.
 
-**The Dusk L1 deposit succeeded but the EVM balance has not changed**
+**A deposit succeeded on Dusk L1, but the DuskEVM balance has not changed**
 
-The deposit may still be processing between layers. Check the originating Dusk L1 transaction first, then the destination address in the DuskEVM explorer.
+Check the Dusk L1 transaction first, then search for the destination account in the DuskEVM explorer. The cross-layer credit may still be processing.
 
 **A withdrawal is still pending**
 
-Pending does not mean failed. Open **Withdrawal status** and select **Check status**. Wait if the status reports **Waiting for output proposal**, **Proof submitted**, or **Waiting to finalize**.
+Select **Check status**. Wait when the status is **Waiting for output proposal**, **Proof submitted**, or **Waiting to finalize**.
 
 **The proof cannot be submitted**
 
-Confirm that the status is **Ready to prove**, the correct Dusk account is unlocked, and the account has enough unshielded DUSK for the proof transaction fee.
+Confirm that the status is **Ready to prove**, the intended Dusk account is unlocked, and it has enough unshielded DUSK for the transaction fee.
 
 **Finalization cannot be submitted**
 
-Confirm that the status is **Ready to finalize**, the correct Dusk account is unlocked, and the account has enough unshielded DUSK for the finalization transaction fee. If the Web Wallet offers **Prove withdrawal** again, submit the newer proof before trying to finalize.
+Confirm that the status is **Ready to finalize** and that the intended Dusk account has enough unshielded DUSK. If the Web Wallet returns to **Ready to prove**, submit the newer proof before trying to finalize again.
 
 ## Next steps
 
-- [Understand how DuskEVM works](/learn/dusk-evm/)
+- [Understand DuskEVM](/learn/dusk-evm/)
 - [Deploy a contract on DuskEVM](/developer/duskevm/quickstart/)

--- a/src/content/docs/learn/guides/legacy.md
+++ b/src/content/docs/learn/guides/legacy.md
@@ -5,7 +5,7 @@ description: Legacy programs and guides kept for transparency. These flows are n
 
 This page collects legacy programs and guides that are no longer active.
 
-If you’re looking to move ERC20/BEP20 DUSK to native DUSK today, use: [ERC20/BEP20 Migration](/learn/guides/mainnet-migration/).
+If you’re looking to move ERC20/BEP20 DUSK to Dusk mainnet today, use the [mainnet migration guide](/learn/guides/mainnet-migration/).
 
 ## Mainnet Genesis On-Ramp (Ended)
 

--- a/src/content/docs/learn/guides/mainnet-migration.md
+++ b/src/content/docs/learn/guides/mainnet-migration.md
@@ -1,75 +1,72 @@
 ---
-title: ERC20/BEP20 Migration
-description: Detailed instructions for migrating your ERC20/BEP20 DUSK tokens to Dusk mainnet.
+title: Migrate ERC20 or BEP20 DUSK to Dusk mainnet
+description: Move DUSK from Ethereum or BSC to Dusk mainnet through the Web Wallet.
 ---
 
-This guide explains how to migrate **ERC20/BEP20 DUSK** (Ethereum/BSC) to **native DUSK** on Dusk mainnet. The migration flow is handled through the [Web Wallet](https://apps.dusk.network/wallet/) and uses WalletConnect to connect your EVM wallet.
+Use the Web Wallet migration flow to lock ERC20 DUSK on Ethereum or BEP20 DUSK on BNB Smart Chain (BSC) and receive the corresponding DUSK on Dusk mainnet.
 
-The migration process locks your ERC20/BEP20 DUSK in a smart contract on Ethereum or Binance Smart Chain. Once locked, an event is emitted and native DUSK is issued to your Dusk wallet. The entire process typically takes around one hour.
+## At a glance
 
-:::note
-Want to bridge **native DUSK to BEP20 DUSK** on BSC instead? See: [Native DUSK to BEP20 Bridge](/learn/guides/bep20-bridge).
+| | |
+|---|---|
+| Direction | Ethereum or BSC to Dusk mainnet |
+| Interface | [Mainnet Web Wallet](https://apps.dusk.network/wallet/) |
+| Confirmations | Approve, if needed, then execute the migration |
+| Typical time | Around one hour after the execution transaction confirms |
+| Network fees | ETH on Ethereum or BNB on BSC for each submitted transaction |
+
+:::caution
+Approval does not migrate your DUSK. You must also select **Execute migration** and confirm that transaction.
 :::
 
-## Who this is for
+## Before you start
 
-- You hold DUSK on Ethereum (ERC20) or Binance Smart Chain (BEP20).
-- You want to use that DUSK on Dusk mainnet (native DUSK).
+You need:
 
-## What you need
+- a Dusk account in the Web Wallet to receive DUSK;
+- a self-custodial EVM wallet that holds ERC20 or BEP20 DUSK and supports WalletConnect; and
+- enough ETH or BNB to pay for up to two transactions on the source network.
 
-- A Dusk wallet (in the Web Wallet) where you want to receive native DUSK.
-- An EVM wallet holding ERC20/BEP20 DUSK that supports WalletConnect.
-- Enough ETH or BNB to pay for two Ethereum/BSC transactions.
+An exchange account normally cannot connect through WalletConnect. Withdraw the tokens to a self-custodial wallet first.
 
-## Expected time and fees
+## Migrate your DUSK
 
-- **Time**: typically around one hour once the **Execute migration** transaction is confirmed.
-- **Fees**: you normally pay an Ethereum/BSC network fee once to approve the migration and again to start it.
+1. Open the [Web Wallet](https://apps.dusk.network/wallet/) and unlock or create the Dusk account that should receive the migrated DUSK.
+2. Open **Migrate**, select **ERC-20** or **BEP-20**, and connect the EVM wallet that holds the tokens.
+3. Enter the amount and select **Initialize migration**.
+4. If prompted, select **Approve migration** and confirm the request in your EVM wallet. Wait for the Web Wallet to confirm the approval.
+5. Select **Execute migration** and confirm the second request. This transaction locks the selected tokens and starts the migration.
 
-## Steps
+The approval step is skipped when the migration contract already has sufficient allowance for the selected amount.
 
-1. Access the [Web Wallet](https://apps.dusk.network/wallet/).
-2. Import an existing wallet or create a new one.
-3. You will be asked to initiate the migration. Review and confirm the process.
-4. Connect your Web3 wallet via WalletConnect.
-5. Select **Approve migration** and confirm the request in your Web3 wallet. This gives the migration permission to use the selected amount of DUSK; it does not move the tokens.
-6. Wait for the Web Wallet to report that approval succeeded.
-7. Select **Execute migration** and confirm the second request in your Web3 wallet. This moves the selected DUSK into the migration process and starts the transfer to your Dusk wallet.
+## Verify the migration
 
-If your Web3 wallet has already granted enough permission for the selected amount, the Web Wallet may proceed directly to **Execute migration**.
+Track the **Execute migration** transaction through the link shown by the Web Wallet or through your EVM wallet. Once processing completes, the DUSK appears in the selected Dusk account. The EVM transaction hash is included in the memo of the corresponding Dusk transaction.
 
-Wait for the issuance of your native DUSK tokens. This process typically takes around one hour.
+Processing normally takes around one hour after the execution transaction confirms. Network conditions can extend that time.
 
-## FAQ
+## Amount precision
 
-**How long does the migration process take?**
+DUSK uses 18 decimal places on Ethereum and BSC, but 9 decimal places on Dusk mainnet. The migration contract therefore rounds the requested amount down to the nearest `LUX`, the smallest Dusk mainnet unit.
 
-The migration process typically completes around one hour after the **Execute migration** transaction is confirmed. Network activity on both chains can affect the timing.
-
-**How can I track my migration transaction?**
-
-Track the second, **Execute migration** transaction in your Web3 wallet on Ethereum or Binance Smart Chain. Once the migration is complete, that transaction hash will be included in the memo field of the Dusk transaction for reference.
-
-**Why does my wallet ask me to confirm twice?**
-
-The first confirmation gives the migration permission to use the selected DUSK. The second confirmation starts the migration. Approving alone does not move any tokens.
-
-**Is there a minimum amount of DUSK I can migrate?**
-
-Yes, the minimum migration amount is 1 LUX, which is equivalent to 1000000000 DUSK wei. Any amount below this will not be accepted by the migration contract.
-
-**What happens if I migrate smaller fractions?**
-
-If you attempt to migrate an amount of DUSK that is not a clean multiple of 1 LUX (1000000000 DUSK wei), the migration contract will round down the amount. For example:
-If you migrate 1234567890 DUSK in wei (ERC20/BEP20), the contract will round it down to 1000000000 DUSK in wei, which is exactly 1 LUX in native DUSK.
-
-This rounding behavior ensures that only full LUX amounts are migrated to native DUSK, as native DUSK uses 9 decimals while ERC20/BEP20 DUSK uses 18 decimals.
+- `1 DUSK = 1,000,000,000 LUX`
+- The minimum migration amount is `1 LUX` (`0.000000001 DUSK`).
+- Any fraction smaller than `1 LUX` is left in the source wallet rather than migrated.
 
 ## Troubleshooting
 
-- **My migration transaction is pending or failed**: check it in your EVM wallet and ensure you have enough ETH/BNB for gas.
-- **Approval succeeded but the migration did not start**: return to the Web Wallet and select **Execute migration**. Approval alone does not move any DUSK.
-- **I don’t see native DUSK after around one hour**: confirm the Ethereum/BSC lock transaction is successful and give it more time during congestion.
-- **My migrated amount is smaller than expected**: amounts are rounded down to full `LUX` (see above).
-- **I’m trying to migrate from an exchange**: exchanges usually can’t connect via WalletConnect. Withdraw your DUSK to a self-custody wallet first.
+**Approval succeeded, but migration did not start**
+
+Return to the Web Wallet and select **Execute migration**. Approval alone does not move any DUSK.
+
+**A transaction is pending or failed**
+
+Check the transaction in your EVM wallet and confirm that the account has enough ETH or BNB for gas. Retry only after the previous transaction has failed or been replaced.
+
+**DUSK has not arrived after around one hour**
+
+Confirm that the **Execute migration** transaction succeeded, not only the approval. Retain its transaction hash when seeking support.
+
+**The received amount is slightly smaller**
+
+The contract rounds down to a whole number of `LUX`. See [Amount precision](#amount-precision).

--- a/src/content/docs/learn/guides/staking-basics.md
+++ b/src/content/docs/learn/guides/staking-basics.md
@@ -1,87 +1,81 @@
 ---
 title: Staking on Dusk
-description: How staking works on Dusk, what you need, and what to expect from rewards and maturity.
+description: Choose a staking method and understand activation, rewards, top-ups, unstaking, and slashing.
 ---
 
-Staking is how Dusk selects provisioners (validator nodes) to propose and validate blocks.
-Stakers earn rewards funded by token emissions and transaction fees.
+Staking secures Dusk by selecting provisioners to propose and validate blocks. Active provisioners earn rewards from token emissions and transaction fees.
 
-## Why stake?
+## At a glance
 
-Staking DUSK allows you to:
+| | |
+|---|---|
+| Minimum direct stake | 1,000 DUSK |
+| Activation | At the epoch boundary after the next one; normally about 6 to 12 hours |
+| Direct staking requirement | A provisioner node that remains online and synchronized |
+| Unstaking | No protocol waiting period; network fees apply |
+| Rewards | Probabilistic, based on consensus participation and active stake |
 
-- Earn staking rewards.
-- Help secure the network by participating in consensus.
+## Choose how to stake
 
-## Two ways to stake
+### Run a provisioner
 
-### 1) Direct staking (run a provisioner)
+Direct staking gives you protocol rewards and responsibility for operating a provisioner node. The node must remain online, synchronized, correctly configured, and on the required software version.
 
-To earn protocol staking rewards directly, you run a provisioner node 24/7 and stake from its wallet.
+1. [Run a provisioner node](/operator/provisioner/).
+2. [Set up its wallet and stake](/operator/guides/node-wallet-setup/).
 
-- Run a node: [Provisioner node](/operator/provisioner)
-- Set up wallet + stake: [Wallet setup](/operator/guides/node-wallet-setup)
+### Use a staking pool
 
-If you are deciding whether to operate infrastructure yourself, read this page first, then move to the operator guide once you are ready to run a node.
+Third-party services and on-chain pools can stake without requiring you to operate a node. Their yield, withdrawal rules, custody model, operator risk, and smart-contract risk are separate from the base protocol.
 
-### 2) Staking pools (no infrastructure)
+Evaluate the provider independently before depositing. Developers building staking pools should see [Stake Abstraction](/learn/hyperstaking/).
 
-Some third-party services and on-chain pools stake on behalf of users. This can let you earn staking yield without running your own node, but it adds operator and smart contract risk.
+## Direct stake lifecycle
 
-- If you're building a pool as a smart contract developer, see: [Stake Abstraction](/learn/hyperstaking)
-- If you're a user, follow the pool/provider's instructions and do your own due diligence.
+### Activation
 
-## Requirements and timing
+A new stake does not participate immediately. It becomes eligible at the start of the epoch after the next epoch boundary.
 
-- **Minimum stake**: 1,000 DUSK
-- **Maturity**: 2 epochs (4,320 blocks), about 12 hours before rewards start
-- **Unstaking**: no penalties or waiting period
+An epoch is 2,160 blocks. Depending on where the staking transaction lands within the current epoch, activation takes between roughly one and two epochs, normally about 6 to 12 hours at the target block time.
 
-:::note[Important]
-New stake only starts earning rewards after the maturity period.
-Operators can verify the `stake active from block` value using `rusk-wallet stake-info`.
-:::
+Check the exact `stake active from block` value with:
 
-## How are rewards determined?
+```sh
+rusk-wallet stake-info
+```
 
-Once your stake is active, rewards are probabilistic and depend on consensus participation and the size of your stake relative to the total active network stake.
+### Rewards
 
-For reward sources and distribution details, see:
+Once active, rewards depend on consensus participation and the stake's size relative to total active stake. They are not a fixed return and may vary between periods.
 
-- [Incentives](/learn/tokenomics#incentives)
-- [Token emission](/learn/tokenomics#token-emission)
+See [Incentives](/learn/tokenomics#incentives) and [Token emission](/learn/tokenomics#token-emission) for how rewards are funded and distributed.
 
-## Slashing
+### Adding to an existing stake
 
-Dusk uses **soft slashing**: stake is not burned, but repeated faults or long downtime can suspend rewards and reduce effective stake.
+- A top-up submitted before the original stake becomes active follows the existing activation schedule.
+- Once the stake is active, 90% of a top-up becomes active immediately and 10% is recorded as locked stake.
+- Locked stake remains yours but does not participate in consensus. Recovering the final locked portion may require fully unstaking the remaining position.
 
-See: [Slashing](/learn/tokenomics#slashing). If you run a provisioner, also read [Slashing prevention and recovery](/operator/guides/slashing-recovery).
+For example, adding 4,000 DUSK to an active stake adds 3,600 DUSK to active stake and 400 DUSK to locked stake.
 
-## Adding to an existing stake
+### Unstaking
 
-You can add to your stake without fully unstaking first.
+There is no protocol waiting period after a successful unstaking transaction. You can fully unstake, or partially unstake while leaving a position that still satisfies the 1,000 DUSK minimum.
 
-- If your stake is already active, **90%** of the additional amount becomes active immediately and starts earning rewards. The remaining **10%** becomes **inactive stake**.
-- Inactive stake does not earn rewards and can only be unlocked by fully unstaking.
-- If you add stake before the original stake becomes active (still in the maturity period), the top-up follows normal maturity and is not subject to the 90%/10% split.
+Unstaking active and locked stake does not automatically withdraw accrued rewards; reward withdrawal is a separate wallet action.
 
-<details>
-<summary><strong>Example</strong></summary>
+## Slashing risk
 
-Suppose you stake **5,000 DUSK**. After the maturity period, your stake becomes active.
+Dusk distinguishes between two classes of consensus penalty:
 
-If you later add **4,000 DUSK**:
+- **Soft penalties** cover failed participation, such as failing to produce a valid candidate. They can suspend eligibility and move part of active stake into locked stake. The locked amount remains owned by the staker.
+- **Hard penalties** cover provably invalid consensus behavior, including invalid votes or signing conflicting proposals or votes. They suspend eligibility and can burn part of the stake.
 
-- **3,600 DUSK (90%)** becomes active immediately.
-- **400 DUSK (10%)** goes to inactive stake.
-
-If you withdraw down to **600 DUSK** active stake, the **400 DUSK** inactive stake remains locked until you fully unstake the remaining active stake.
-
-</details>
+Run only supported software and never run the same consensus key on multiple active nodes. Operators should follow [Slashing prevention and recovery](/operator/guides/slashing-recovery/).
 
 ## Next steps
 
-- Direct staking (run your own node): [Provisioner node](/operator/provisioner), then [Wallet setup](/operator/guides/node-wallet-setup)
-- Operator maintenance after staking: [Maintenance & monitoring](/operator/maintenance-monitoring)
-- Understand rewards and emissions: [Tokenomics](/learn/tokenomics)
-- If you hold ERC20/BEP20 DUSK: [Mainnet migration](/learn/guides/mainnet-migration)
+- [Run a provisioner node](/operator/provisioner/)
+- [Set up a node wallet](/operator/guides/node-wallet-setup/)
+- [Monitor a provisioner](/operator/maintenance-monitoring/)
+- [Understand DUSK tokenomics](/learn/tokenomics/)

--- a/src/content/docs/learn/hyperstaking.md
+++ b/src/content/docs/learn/hyperstaking.md
@@ -30,8 +30,8 @@ Contracts can implement arbitrary reward-splitting rules (for example: route a p
 ## Protocol-level notes
 
 - The **minimum stake** requirement applies to contracts too: **1,000 DUSK**.
-- Stake is considered active after a maturity period of **4320 blocks (~12 hours)**.
-- Reward distribution depends on consensus participation; see [Staking on Dusk](/learn/guides/staking-basics#how-are-rewards-determined).
+- Stake becomes active at the epoch boundary after the next one, between roughly 1 and 2 epochs after submission.
+- Reward distribution depends on consensus participation; see [Staking on Dusk](/learn/guides/staking-basics#rewards).
 
 ## Technical guide (smart contract developers)
 

--- a/src/content/docs/learn/tokenomics.md
+++ b/src/content/docs/learn/tokenomics.md
@@ -5,14 +5,14 @@ description: DUSK token utility, supply, emissions, and staking incentives.
 
 DUSK is the native token used for transaction fees (gas) and staking on the Dusk network.
 
-If you hold ERC20/BEP20 DUSK (on Ethereum/BSC), follow the [mainnet migration guide](/learn/guides/mainnet-migration) to move to native DUSK.
+If you hold ERC20/BEP20 DUSK (on Ethereum/BSC), follow the [mainnet migration guide](/learn/guides/mainnet-migration) to move it to Dusk mainnet.
 
 For economic model rationale and assumptions, see the <a href="https://github.com/dusk-network/audits/blob/main/core-audits/2024-09_protocol-security-review_oak-security.pdf" target="_blank" rel="noreferrer">Economic Protocol Design</a> report.
 
 ## Quick facts
 
 - **Symbol**: DUSK
-- **Decimals (native DUSK)**: 9 (`1 DUSK = 1,000,000,000 LUX`)
+- **Decimals (Dusk mainnet)**: 9 (`1 DUSK = 1,000,000,000 LUX`)
 - **Decimals (ERC20/BEP20 DUSK)**: 18 (see [migration guide](/learn/guides/mainnet-migration))
 - **Supply model**: 500,000,000 initial + 500,000,000 emitted over time (max 1,000,000,000)
 - **Live supply**: see [supply.dusk.network](https://supply.dusk.network/)
@@ -39,8 +39,8 @@ For the user-facing flow, see [Staking on Dusk](/learn/guides/staking-basics).
 
 - **Minimum stake**: 1,000 DUSK
 - **Maximum stake**: no upper bound
-- **Maturity**: 2 epochs (4,320 blocks)
-- **Unstaking**: no penalties or waiting period
+- **Activation**: at the epoch boundary after the next one; between roughly 1 and 2 epochs depending on submission height
+- **Unstaking**: no protocol waiting period; a partial position must retain the minimum stake
 - **Adding to stake (top-ups)**: see [Adding to an existing stake](/learn/guides/staking-basics#adding-to-an-existing-stake)
 
 ## Incentives
@@ -81,13 +81,12 @@ Emissions follow a geometric decay model with reduction rate `r = 0.5` (halving 
 
 ## Slashing
 
-Dusk uses **soft slashing** to discourage repeated faults and long downtime.
-Soft slashing does not burn stake; it reduces a provisioner's effective participation and rewards.
+Dusk distinguishes between soft and hard consensus penalties:
 
-- **Suspension**: stake is suspended for one or more epochs (not eligible for selection; earns no rewards).
-- **Penalization**: a portion of stake is moved to the claimable rewards pool, reducing effective stake used in sortition.
+- **Soft penalties** apply to failed participation. They can suspend the provisioner and move part of active stake into locked stake. Locked stake does not participate but remains owned by the staker.
+- **Hard penalties** apply to provably invalid consensus behavior, such as invalid votes or signing conflicting proposals or votes. They suspend the provisioner and can burn part of its stake.
 
-In practice: run official software, keep it updated and online, and monitor missed duties.
+Run supported software, keep the node synchronized, and never run the same consensus key on multiple active nodes. See [Slashing prevention and recovery](/operator/guides/slashing-recovery/).
 
 ## Token versions and contracts
 

--- a/src/content/docs/operator/faq.md
+++ b/src/content/docs/operator/faq.md
@@ -40,7 +40,7 @@ Yes. You can run a node for syncing, propagation, and APIs without staking, but 
 
 #### When does my stake become active?
 
-After the 4320-block maturity period (about 12 hours). See [/learn/guides/staking-basics](/learn/guides/staking-basics).
+At the epoch boundary after the next one, between roughly 1 and 2 epochs after the staking transaction. Check `stake active from block` with `rusk-wallet stake-info`. See [Staking on Dusk](/learn/guides/staking-basics/).
 
 #### How do I increase stake or compound rewards?
 

--- a/src/content/docs/operator/guides/node-wallet-setup.md
+++ b/src/content/docs/operator/guides/node-wallet-setup.md
@@ -11,7 +11,7 @@ You can use the node installer guide to [quickly launch your Provisioner node](/
 
 This guide explains setting up the wallet and the last steps needed to start running your node.
 
-For the staking model, maturity period, reward timing, and unstaking behavior, read [Staking on Dusk](/learn/guides/staking-basics) alongside this operator setup guide.
+For the staking model, activation timing, reward timing, and unstaking behavior, read [Staking on Dusk](/learn/guides/staking-basics) alongside this operator setup guide.
 
 ## Preparation
 
@@ -136,6 +136,6 @@ rusk-wallet stake-info --profile-idx 0 # Replace with a different profile if app
 
 Check for the `eligible stake` and `stake active from block` fields to be updated.
 
-**Note**: Your stake takes 2 epochs (4320 blocks) to mature. Only after that will it start participating in consensus.
+Activation occurs at the epoch boundary after the next one, between roughly 1 and 2 epochs after submission. Use the reported `stake active from block` value rather than estimating from elapsed time.
 
 You can periodically run `rusk-wallet stake-info` to monitor if your accumulated rewards are increasing, which is a clear indicator that your node is successfully participating in consensus.

--- a/src/content/docs/operator/guides/slashing-recovery.md
+++ b/src/content/docs/operator/guides/slashing-recovery.md
@@ -1,17 +1,22 @@
 ---
 title: Slashing prevention and recovery
-description: Learn how Dusk soft slashing affects provisioners and what to check after a slashing event.
+description: Diagnose provisioner penalties, restore healthy operation, and reduce soft- and hard-slashing risk.
 ---
 
-Dusk uses **soft slashing** to discourage repeated faults and long downtime. Stake is not burned, but a provisioner can lose eligibility or effective participation, which reduces rewards.
+Dusk applies different penalties to failed participation and provably invalid consensus behavior:
 
-Soft slashing can happen when a provisioner repeatedly fails to participate correctly in consensus. Common operational causes include:
+- **Soft penalties** can suspend eligibility and move part of active stake into locked stake. Locked stake remains owned and can be unstaked.
+- **Hard penalties** can suspend eligibility and burn part of the stake. Burned stake cannot be recovered by restarting or restaking.
+
+Failed participation is usually an operational problem. Common causes include:
 
 - Running an outdated or incompatible node version.
 - Being offline for too long.
 - Falling behind the network tip.
 - Network or firewall problems that prevent consensus messages from being sent or received.
 - Consensus key or node configuration issues.
+
+Hard penalties apply to invalid consensus votes and equivocation, including signing conflicting proposals or votes. Running the same consensus key on multiple active nodes can cause this behavior and must be avoided.
 
 ## If your provisioner was slashed
 
@@ -86,11 +91,11 @@ ruskquery block-height
 
 The height should continue to progress. If the node falls behind again, treat it as an unresolved infrastructure or networking issue.
 
-### 6. Unstake and restake if the node is healthy
+### 6. Unstake and restake only after the node is healthy
 
-If the node is on the right version, fully synced, and operating normally, unstake and restake to restore normal provisioner participation.
+If the node is on the right version, fully synced, operating normally, and the consensus key is active on only one node, unstake and restake when needed to create a new provisioner position.
 
-Slashing can be caused by temporary operational issues, such as cloud provider downtime, network disruption, or downtime during a live node update. If the underlying issue is gone, restaking is the recovery step.
+Restaking starts a new activation period. It does not restore stake burned by a hard penalty, so identify the underlying cause before submitting either transaction.
 
 ```sh
 rusk-wallet unstake
@@ -106,6 +111,7 @@ Replace `<amount>` with the amount you want to stake. The new stake must mature 
 - Alert on service downtime and repeated restart loops.
 - Keep UDP `9000` reachable for Kadcast.
 - Keep consensus keys backed up and readable by the Rusk service.
+- Never run the same consensus key on multiple active nodes.
 - Avoid running experimental or mismatched binaries on a staked provisioner.
 - Use [fast-sync](/operator/guides/fast-sync) when a node falls behind instead of waiting for a long resync from genesis.
 


### PR DESCRIPTION
## Summary

- give the migration, BSC bridge, DuskEVM bridge, and staking guides a concise shared structure: at-a-glance facts, prerequisites, exact steps, verification, and recovery guidance
- clarify that ERC20/BEP20 migration requires approval and execution, document LUX rounding, and make the BSC bridge fee, minimum useful amount, and memo risk explicit
- align the DuskEVM testnet bridge guide with the current three-action withdrawal flow and the status labels introduced by dusk-network/web-wallet#947
- correct staking documentation across user and operator pages: activation varies between roughly one and two epochs, active-stake top-ups use the 90/10 split, and hard consensus penalties can burn stake
- replace remaining "native DUSK" labels with explicit Dusk mainnet terminology

## Why

The practical guides had accumulated repeated prose while still leaving important transaction boundaries and failure cases implicit. Some staking pages also described activation as a fixed 4,320-block delay and slashing as soft-only, neither of which matches the current protocol implementation.

The revised pages optimize for a user completing or verifying a task while preserving the distinctions that affect funds and operator risk.

## Validation

Claims were cross-checked against the current `dusk-migration` contract, Web Wallet migration and bridge implementations, `bridge-replayer`, Rusk, and the pinned Rusk contracts revision.

- `npm run build` (59 pages; all internal links valid)
- `git diff --check`
- repository-wide stale-claim scan for the replaced activation, slashing, migration-title, and "native DUSK" wording
- desktop and 390 px Chromium visual checks of all four primary guides

## Notes

The DuskEVM guide describes the interface being prepared in [dusk-network/web-wallet#947](https://github.com/dusk-network/web-wallet/pull/947), so that guide should ship with or after the corresponding Web Wallet change.
