### PR TITLE
Add network and developer updates

### DIFF
--- a/src/content/docs/updates/developer/2026-08-04-to-2026-08-11.md
+++ b/src/content/docs/updates/developer/2026-08-04-to-2026-08-11.md
@@ -1,0 +1,81 @@
+---
+title: "August 4–11, 2026"
+description: "Verified engineering progress across Dusk's node, runtime, cryptography, zero-knowledge, DuskEVM, tooling, and application repositories."
+sidebar:
+  hidden: true
+---
+
+[← Developer Updates](/updates/developer/)
+
+This update covers verified merged pull requests and public releases across Dusk repositories during the previous seven days. Work in private repositories is summarized without linking to private implementation details; public changes are linked alongside their respective projects.
+
+## Rusk
+
+Private node, wallet, and VM development focused on safer state transitions, compatibility, and recovery:
+
+- added production-shaped replay, checkpoint reopening, wallet TUI transition coverage, and safer handling of non-UTF-8 key paths;
+- bound archive event batches to finalized block hashes, preserved event order, and tightened proposal accounting;
+- validated blob sidecars before state transition, introduced metered `BlobCall` handling behind a disabled feature gate, and updated Piecrust with atomic-failure regressions; and
+- hardened wallet amount parsing, chain-ID validation, fee arithmetic, and provisioner-key export reporting.
+
+## DuskEVM
+
+Private contracts and adapter development tightened blob submission, bridge routing, fault-proof state, RPC limits, and withdrawal recovery:
+
+- aligned MIPS and preimage behavior with the pinned Optimism and Karst expectations;
+- isolated delayed-withdrawal maturity by game and strengthened relay, proof-timestamp, claim-index, and finality boundaries; and
+- added bounded RPC decoding, admission, and session paths; canonical blob reconstruction; projected preimage and challenger state; and stricter malformed-event handling.
+
+## PLONK
+
+PLONK work strengthened circuit soundness, checked deserialization, and core-only behavior:
+
+- expanded coverage for curve-addition, fixed-base, and logic helper wires ([#882](https://github.com/dusk-network/plonk/pull/882), [#883](https://github.com/dusk-network/plonk/pull/883), [#885](https://github.com/dusk-network/plonk/pull/885), [#894](https://github.com/dusk-network/plonk/pull/894), [#911](https://github.com/dusk-network/plonk/pull/911));
+- prevented malformed point witnesses from reaching panicking projections ([#891](https://github.com/dusk-network/plonk/pull/891), [#907](https://github.com/dusk-network/plonk/pull/907));
+- validated KZG keys, cached vanishing and linear evaluations, point inputs, and reconstructed public parameters before use ([#888](https://github.com/dusk-network/plonk/pull/888), [#893](https://github.com/dusk-network/plonk/pull/893), [#899](https://github.com/dusk-network/plonk/pull/899), [#900](https://github.com/dusk-network/plonk/pull/900), [#904](https://github.com/dusk-network/plonk/pull/904), [#905](https://github.com/dusk-network/plonk/pull/905), [#909](https://github.com/dusk-network/plonk/pull/909)); and
+- rejected trailing compressed-circuit data while making the error API non-exhaustive and usable in core-only builds ([#866](https://github.com/dusk-network/plonk/pull/866), [#886](https://github.com/dusk-network/plonk/pull/886), [#896](https://github.com/dusk-network/plonk/pull/896)).
+
+## JubJub Schnorr
+
+Secret-key and multisignature handling received several safety improvements:
+
+- secret keys are redacted from debug output ([#46](https://github.com/dusk-network/jubjub-schnorr/pull/46));
+- variable-time secret-key ordering was removed ([#56](https://github.com/dusk-network/jubjub-schnorr/pull/56));
+- variable-generator secret keys can no longer be copied implicitly ([#57](https://github.com/dusk-network/jubjub-schnorr/pull/57));
+- multisignature nonce state is single-use ([#47](https://github.com/dusk-network/jubjub-schnorr/pull/47));
+- double signatures bind both public keys ([#49](https://github.com/dusk-network/jubjub-schnorr/pull/49)); and
+- share-combination inputs and nonce-reuse diagnostics are explicitly validated and tested ([#61](https://github.com/dusk-network/jubjub-schnorr/pull/61), [#62](https://github.com/dusk-network/jubjub-schnorr/pull/62)).
+
+## JubJub ElGamal
+
+Checked RKYV decoding now validates archived ElGamal ciphertext points before constructing live cryptographic values ([#30](https://github.com/dusk-network/jubjub-elgamal/pull/30)).
+
+## Phoenix
+
+Checked deserialization now verifies that archived note openings match their commitments before accepting them ([#291](https://github.com/dusk-network/phoenix/pull/291)).
+
+## Merkle
+
+Tree operations now reject inconsistent paths ([#112](https://github.com/dusk-network/merkle/pull/112)) and out-of-range opening positions ([#113](https://github.com/dusk-network/merkle/pull/113)) without partially mutating otherwise valid tree state.
+
+## Dusk Bytes
+
+Reader-backed decoding now consumes exactly the required number of bytes ([#40](https://github.com/dusk-network/dusk-bytes/pull/40)), and hexadecimal decoding rejects odd-length input before indexing it ([#41](https://github.com/dusk-network/dusk-bytes/pull/41)).
+
+## Piecrust
+
+Public runtime maintenance preserved synthetic root ancestry ([#495](https://github.com/dusk-network/piecrust/pull/495)) and hardened top-level call boundaries ([#497](https://github.com/dusk-network/piecrust/pull/497)). The corresponding refinements shipped in [`0.32.1`](https://github.com/dusk-network/piecrust/releases/tag/piecrust-0.32.1) and [`0.32.2`](https://github.com/dusk-network/piecrust/releases/tag/piecrust-0.32.2). Private development continued improving contract-memory finalization.
+
+## zk-tools
+
+The new zk-tools project established its workspace structure ([#1](https://github.com/dusk-network/zk-tools/pull/1)), moved BLS12-381 support to Dusk curves ([#3](https://github.com/dusk-network/zk-tools/pull/3)), decoupled the composer from PLONK ([#4](https://github.com/dusk-network/zk-tools/pull/4)), and implemented Groth16 tooling ([#8](https://github.com/dusk-network/zk-tools/pull/8)).
+
+## Citadel
+
+Citadel migrated to the current Dusk curve stack ([#148](https://github.com/dusk-network/citadel/pull/148)), repaired the resulting API changes ([#149](https://github.com/dusk-network/citadel/pull/149)), and updated its zk-tools dependency to `0.2.0` ([#151](https://github.com/dusk-network/citadel/pull/151)).
+
+## Web Wallet
+
+Active DuskEVM bridge flows migrated to the current contracts and published SDK, including versioned encoding for external recipients ([#947](https://github.com/dusk-network/web-wallet/pull/947)).
+
+[← Back to Developer Updates](/updates/developer/)

--- a/src/content/docs/updates/developer/index.mdx
+++ b/src/content/docs/updates/developer/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Developer Updates
+description: Browse periodic Dusk engineering updates by publication date and covered interval, with summaries, project sections, and source links.
+---
+
+Developer updates summarize engineering work over a stated interval. Updates are listed newest first.
+
+## [August 4–11, 2026](/updates/developer/2026-08-04-to-2026-08-11/)
+
+A security- and compatibility-focused week spanning Rusk, DuskEVM, PLONK, Schnorr, Piecrust, zk-tools, and application integrations.

--- a/src/content/docs/updates/network/aegis.md
+++ b/src/content/docs/updates/network/aegis.md
@@ -1,0 +1,73 @@
+---
+title: Aegis
+sidebar:
+  hidden: true
+description: Activation details, protocol changes, security hardening, and operator impact for the Dusk Aegis hard fork.
+---
+
+[← Network Updates](/updates/network/)
+
+Aegis was a coordinated cryptographic and protocol-security upgrade delivered in Rusk 1.6.0. It introduced new proof and signature verification rules while preserving the rules needed to replay blocks produced before the fork.
+
+## Activation
+
+| Network | Activation time (UTC) | Activation height | Required Rusk | Release |
+| --- | --- | ---: | --- | --- |
+| Testnet | March 3, 2026, 10:53 | 2,773,727 | 1.6.0 | [Rusk 1.6.0](https://github.com/dusk-network/rusk/releases/tag/dusk-rusk-1.6.0) |
+| Mainnet | March 3, 2026, 11:06 | 3,590,904 | 1.6.0 | [Rusk 1.6.0](https://github.com/dusk-network/rusk/releases/tag/dusk-rusk-1.6.0) |
+
+The heights are defined independently for each network. The dates and times are taken from the corresponding activation-block headers.
+
+## Protocol Changes at the Fork
+
+### PLONK V3 verification
+
+Transactions at and after Aegis are verified using PLONK V3. Rusk selects the verifier from the block height: historical blocks continue to use their original PLONK V1 or V2 rules, while new proofs use V3.
+
+This was a change to the consensus verification boundary, not only a dependency update. A node using the wrong verifier at the activation height would calculate different transaction validity from the network.
+
+### Versioned BLS signatures
+
+Aegis moved the network to the hardened V2 BLS behavior across:
+
+- consensus quorum signing and verification;
+- block-header and seed validation; and
+- BLS host queries used by contracts.
+
+The legacy BLS behavior remains available only for validating historical pre-Aegis data. The same block-height policy is shared by the consensus, node-data, Rusk, and virtual-machine layers so they cannot silently select different signature rules.
+
+### Phoenix fee and refund binding
+
+Aegis added a consensus check binding the Phoenix gas-refund stealth address to the change note proven by the transaction. This prevents a block producer or modified transaction envelope from redirecting a valid transaction's refund to another address. The existing maximum-fee check and the new refund-address check are both enforced without changing the validity of historical transactions.
+
+## Hardening Shipped with Rusk 1.6.0
+
+The required release also contained a wider security-hardening set. These changes shipped with the Aegis upgrade, but were not all activated by the Aegis block-height switch:
+
+- validated RKYV decoding at wallet, node, archive, VM, and test boundaries;
+- bounded decoding for transactions, blocks, inventory messages, spent-transaction errors, and Phoenix proof data;
+- integer supermajority calculation and stricter consensus signer, ratification, and emergency-vote validation;
+- transaction preverification before HTTP propagation;
+- limits for HTTP bodies, WebSocket messages, and expensive GraphQL ranges; and
+- safer handling of missing stake entries during slashing.
+
+Keeping this distinction matters: the hard fork changed consensus behavior at an exact height, while the rest of Rusk 1.6.0 hardened how nodes receive, decode, and process data around that protocol.
+
+## Operator and Developer Impact
+
+Operators on both networks needed Rusk 1.6.0 before their respective activation heights. Earlier versions cannot validate the post-Aegis chain correctly.
+
+Proof-producing software must create the active proof version for new transactions. Historical synchronization still requires the older verifier and BLS rules, which is why those implementations remain present in Rusk even though they must not be used for newly produced post-Aegis data.
+
+For current node maintenance procedures, see [Upgrade a Node](/operator/guides/upgrade-node/).
+
+## Canonical Sources
+
+- [Rusk 1.6.0 release](https://github.com/dusk-network/rusk/releases/tag/dusk-rusk-1.6.0)
+- [Rusk 1.6.0 changelog](https://github.com/dusk-network/rusk/blob/dusk-rusk-1.6.0/rusk/CHANGELOG.md#160---2026-02-27)
+- [Mainnet and testnet Aegis activation configuration](https://github.com/dusk-network/rusk/blob/dusk-rusk-1.6.0/rusk/src/lib/node/vm/config/known.rs)
+- [Fork-aware PLONK selection](https://github.com/dusk-network/rusk/blob/dusk-rusk-1.6.0/rusk/src/lib/node/rusk.rs)
+- [Versioned BLS implementation](https://github.com/dusk-network/rusk/blob/dusk-rusk-1.6.0/core/src/lib.rs)
+- [Phoenix fee and refund checks](https://github.com/dusk-network/rusk/blob/dusk-rusk-1.6.0/core/src/transfer.rs)
+
+[← Back to Network Updates](/updates/network/)

--- a/src/content/docs/updates/network/boreas.md
+++ b/src/content/docs/updates/network/boreas.md
@@ -1,0 +1,101 @@
+---
+title: Boreas
+sidebar:
+  hidden: true
+description: Activation details, transaction and execution changes, compatibility rules, and operator impact for the Dusk Boreas hard fork.
+---
+
+[← Network Updates](/updates/network/)
+
+Boreas was a broad transaction, execution, and state-transition upgrade delivered by the Rusk 1.7 release line. It first activated on testnet and later became the protocol boundary used for the coordinated mainnet restart.
+
+## Activation
+
+| Network | Activation time (UTC) | Activation height | Required Rusk | Release line |
+| --- | --- | ---: | --- | --- |
+| Testnet | May 27, 2026, 13:03 | 3,378,000 | Boreas-capable 1.7 RC | [Rusk 1.7.0](https://github.com/dusk-network/rusk/releases/tag/dusk-rusk-1.7.0) |
+| Mainnet | June 10, 2026 deployment | 4,414,095 | 1.7.0 | [Rusk 1.7.0](https://github.com/dusk-network/rusk/releases/tag/dusk-rusk-1.7.0) |
+
+Testnet reached its configured activation block before the final 1.7.0 release. Mainnet resumed from block `4_414_095` during the coordinated June 10 deployment. Because that restart reused an existing chain snapshot, its first block retained a June 6 header timestamp; June 10 is the date the Boreas rules actually went live on mainnet.
+
+Phoenix disablement followed a separate testnet schedule:
+
+| Network | Activation time (UTC) | Height | Behavior |
+| --- | --- | ---: | --- |
+| Mainnet | June 10, 2026 deployment | 4,414,095 | Phoenix disabled with the Boreas restart |
+| Testnet | August 7, 2026, 12:54 | 4,000,000 | Phoenix disabled after the Boreas trial period |
+
+## Protocol Changes at the Fork
+
+### Canonical and versioned transactions
+
+Boreas introduced explicit boundaries between transactions accepted from clients, their canonical in-memory representation, and the ledger format committed into blocks. Rusk now:
+
+- decodes live ingress according to the active protocol version;
+- accepts legacy Aegis envelopes at the network boundary and normalizes them;
+- canonicalizes locally sealed transactions before committing them; and
+- retains the historical decoders needed to replay pre-Aegis and pre-Boreas blocks.
+
+This prevents the mempool, block producer, consensus validation, and historical replay paths from interpreting the same bytes under different transaction rules.
+
+### VM execution and gas accounting
+
+Boreas changed consensus-critical execution policy in several places:
+
+- deployment gas checks and initialization charging became fork-aware;
+- SHA-256, KZG verification, secp256k1 recovery, and Keccak host queries use the network's configured activation and pricing rules;
+- hash-query gas is charged from the amount of input processed;
+- VM cache keys include the active hard-fork and verifier semantics; and
+- reference-type deployment validation is selected from the historical feature timeline.
+
+The gates preserve the old behavior for replay while making post-Boreas gas accounting deterministic across nodes.
+
+### State-transition ordering
+
+After Boreas, slashes are applied before transaction execution. This closes a same-block ordering case in which stake could otherwise be changed before the pending slash was applied. Pre-Boreas blocks retain their original ordering during replay.
+
+### Reverted-event semantics
+
+Boreas made reverted contract events explicit across execution, block headers, archive storage, and provisioner updates:
+
+- reverted events are retained with a `reverted` marker for archive consumers;
+- they are removed from the canonical block bloom after Boreas; and
+- reverted stake events are excluded from the provisioner's state updates.
+
+Historical event decoding remains supported so existing archives and old blocks can still be read.
+
+### Phoenix retirement
+
+Mainnet disabled new Phoenix transactions at the restart boundary. Nodes still keep Phoenix decoding and historical execution support because old blocks must remain replayable. Testnet kept Phoenix available beyond its Boreas activation and disabled it later at block `4_000_000`.
+
+The disablement applies at transaction admission and execution boundaries. It does not erase historical Phoenix state or remove the code required to synchronize the chain.
+
+## Node and API Changes in Rusk 1.7.0
+
+The release also shipped operational changes that were not all direct fork-height rules:
+
+- full ledger headers became the source of truth for VM session commit, finalization, revert, and provisioner queries;
+- startup recovers the current tip header from the chain database;
+- future-nonce Moonlight transactions can be queued during HTTP propagation;
+- mempool replacement requires an improving gas price;
+- HTTP ingress gained ACL and endpoint-class rate and concurrency limits;
+- wallet and wallet-core gained Boreas-compatible transaction, deployment, and history handling; and
+- the compatibility replay suite began exercising filled state and transactions across the Aegis and Boreas boundaries.
+
+## Operator and Developer Impact
+
+Operators had to upgrade before the activation applicable to their network. Mainnet's change was a coordinated restart rather than an ordinary future-height transition.
+
+Clients may continue to submit supported Aegis transaction envelopes because Rusk normalizes them at live ingress, but blocks use the active canonical ledger format. New Phoenix transactions are rejected after the network-specific disable height; Moonlight remains the supported transaction model. Archive and indexer consumers should use the reverted marker rather than assuming every stored event contributed to canonical state.
+
+For current node maintenance procedures, see [Upgrade a Node](/operator/guides/upgrade-node/).
+
+## Canonical Sources
+
+- [Rusk 1.7.0 release](https://github.com/dusk-network/rusk/releases/tag/dusk-rusk-1.7.0)
+- [Rusk 1.7.0 changelog](https://github.com/dusk-network/rusk/blob/dusk-rusk-1.7.0/rusk/CHANGELOG.md#170---2026-06-10)
+- [Mainnet and testnet Boreas activation configuration](https://github.com/dusk-network/rusk/blob/dusk-rusk-1.7.0/rusk/src/lib/node/vm/config/known.rs)
+- [Fork-coupled execution policy](https://github.com/dusk-network/rusk/blob/dusk-rusk-1.7.0/rusk/src/lib/node/fork_policy.rs)
+- [Canonical and ledger transaction types](https://github.com/dusk-network/rusk/blob/dusk-rusk-1.7.0/node-data/src/ledger/transaction.rs)
+
+[← Back to Network Updates](/updates/network/)

--- a/src/content/docs/updates/network/index.mdx
+++ b/src/content/docs/updates/network/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Network Updates
+description: Follow verified Dusk mainnet and testnet hard-fork activations, their required Rusk versions, and canonical release sources.
+---
+
+Network updates record changes to Dusk protocol behavior on mainnet and testnet. Updates are listed newest first. Operators should follow the instructions in each update and use the linked Rusk release as the canonical software source.
+
+## Hard-Fork Updates
+
+### [Boreas](/updates/network/boreas/)
+
+**Testnet block 3,378,000 · Mainnet restart block 4,414,095 · Rusk 1.7**
+
+Introduced canonical, version-aware transaction handling; fork-aware VM pricing and deployment rules; new state-transition and reverted-event semantics; and the network-specific retirement of Phoenix transactions.
+
+### [Aegis](/updates/network/aegis/)
+
+**Testnet block 2,773,727 · Mainnet block 3,590,904 · Rusk 1.6.0**
+
+Activated PLONK V3, versioned BLS consensus and host-query behavior, and Phoenix refund-address binding, alongside a wider consensus and decoding hardening release.
+
+## Historical Activations
+
+The table includes earlier mainnet protocol activations only when the height, date, and supporting Rusk release can be verified from canonical chain, source, and release records.
+
+| Activation | Height | Date (UTC) | Required Rusk | Release |
+| --- | ---: | --- | --- | --- |
+| PLONK V2 | 3,470,360 | February 17, 2026 | 1.5.0 | [`dusk-rusk-1.5.0`](https://github.com/dusk-network/rusk/releases/tag/dusk-rusk-1.5.0) |
+| Blob transactions | 2,873,420 | December 10, 2025 | 1.4.1 | [`dusk-rusk-1.4.1`](https://github.com/dusk-network/rusk/releases/tag/dusk-rusk-1.4.1) |
+| Public sender ABI | 355,000 | February 17, 2025 | 1.1.0 | [`dusk-rusk-1.1.0`](https://github.com/dusk-network/rusk/releases/tag/dusk-rusk-1.1.0) |
+
+Activation heights are defined in Rusk's [mainnet configuration](https://github.com/dusk-network/rusk/blob/311cc64df1018a9960babd19bc2b6d2e7bc3d4f3/rusk/src/lib/node/vm/config/known.rs). Dates correspond to the timestamps of the activation blocks. Entries without sufficient canonical evidence are intentionally omitted.

--- a/src/sidebars/siteSidebar.js
+++ b/src/sidebars/siteSidebar.js
@@ -169,6 +169,14 @@ const siteSidebar = [
       },
     ],
   },
+  {
+    label: "Updates",
+    collapsed: false,
+    items: [
+      { label: "Network Updates", link: "/updates/network" },
+      { label: "Developer Updates", link: "/updates/developer" },
+    ],
+  },
 ];
 
 export default siteSidebar;

--- a/templates/developer-update.mdx
+++ b/templates/developer-update.mdx
@@ -1,0 +1,26 @@
+---
+# Copy this file to src/content/docs/updates/developer/<descriptive-slug>.mdx.
+# Replace every example value and all instructional body text before publishing.
+title: "Month D–D, YYYY"
+description: "A concise Dusk engineering update covering the stated interval."
+sidebar:
+  hidden: true
+---
+
+[← Developer Updates](/updates/developer/)
+
+Open with a short summary of the verified outcomes covered by the update.
+
+## Project or Workstream
+
+Describe completed work, material progress, decisions, and user impact. Distinguish shipped changes from work in progress and link to canonical evidence.
+
+Add one second-level section for each project or workstream. Omit empty sections.
+
+## Related Links
+
+- Add a canonical release, pull request, issue, specification, or announcement link.
+
+After creating the article, add a second-level date-range heading and short summary to `src/content/docs/updates/developer/index.mdx`. Keep the newest update first. Do not add the article to the main sidebar.
+
+[← Back to Developer Updates](/updates/developer/)


### PR DESCRIPTION
## Summary

- add a final **Updates** sidebar group with only Network Updates and Developer Updates
- publish verified Aegis and Boreas hard-fork pages plus a newest-first network index and historical activation table
- add an automatically sorted developer-update index, frontmatter contract, and non-rendered authoring template
- keep every detail article out of the sidebar while preserving normal routes, search, tables of contents, and back navigation

## Validation

- `npm ci`
- `node scripts/verify-package-release-ages.cjs --days 7`
- `npm audit signatures`
- `npm rebuild esbuild`
- `npm run build` (includes internal link validation)
- temporary template-copy build verified automatic developer-index discovery and ordering
- generated-route and sidebar assertions verified all four routes, exactly two Updates links, and no detail-page children
- activation heights and block timestamps re-queried against the mainnet GraphQL endpoint and cross-checked with pinned Rusk source and releases

Closes #138
Closes #139
