### PR TITLE
Publish docs crawler entry points and social previews

### DIFF
--- a/.github/workflows/validate_links.yml
+++ b/.github/workflows/validate_links.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Run approved dependency scripts
         run: npm rebuild esbuild
 
-      - name: Build and validate links
-        run: npm run build
+      - name: Build, test, and validate links
+        run: npm run verify

--- a/astro.config.js
+++ b/astro.config.js
@@ -65,6 +65,34 @@ export default defineConfig({
 			sidebar: siteSidebar,
 			plugins: [starlightLinksValidator()],
 			head: [
+				{
+					tag: "meta",
+					attrs: {
+						property: "og:image",
+						content: "https://dusk.network/images/social/dusk-social-preview-og.png",
+					},
+				},
+				{
+					tag: "meta",
+					attrs: {
+						property: "og:image:alt",
+						content: "Dusk - Regulated markets, settled on-chain",
+					},
+				},
+				{
+					tag: "meta",
+					attrs: {
+						name: "twitter:image",
+						content: "https://dusk.network/images/social/dusk-social-preview-twitter.png",
+					},
+				},
+				{
+					tag: "meta",
+					attrs: {
+						name: "twitter:image:alt",
+						content: "Dusk - Regulated markets, settled on-chain",
+					},
+				},
 				// Adding google analytics
 				{
 					tag: 'script',

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "test": "node --test",
     "build": "astro build",
+    "verify": "node --test && astro build",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "dev": "astro dev",
     "start": "astro dev",
     "test": "node --test",
-    "build": "astro build",
-    "verify": "node --test && astro build",
+    "build": "astro build && node scripts/create-sitemap-alias.mjs",
+    "verify": "npm run build && node --test",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.dusk.network/sitemap-index.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <sitemap>
-    <loc>https://docs.dusk.network/sitemap-0.xml</loc>
-  </sitemap>
-</sitemapindex>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://docs.dusk.network/sitemap-0.xml</loc>
+  </sitemap>
+</sitemapindex>

--- a/scripts/create-sitemap-alias.mjs
+++ b/scripts/create-sitemap-alias.mjs
@@ -1,0 +1,6 @@
+import { copyFile } from "node:fs/promises";
+
+const generatedIndex = new URL("../dist/sitemap-index.xml", import.meta.url);
+const conventionalAlias = new URL("../dist/sitemap.xml", import.meta.url);
+
+await copyFile(generatedIndex, conventionalAlias);

--- a/test/machine-files.test.mjs
+++ b/test/machine-files.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const readPublicFile = (name) =>
+  readFile(new URL(`../public/${name}`, import.meta.url), "utf8");
+
+test("robots.txt permits crawling and advertises the generated sitemap index", async () => {
+  const robots = await readPublicFile("robots.txt");
+
+  assert.match(robots, /^User-agent: \*$/m);
+  assert.match(robots, /^Allow: \/$/m);
+  assert.match(
+    robots,
+    /^Sitemap: https:\/\/docs\.dusk\.network\/sitemap-index\.xml$/m,
+  );
+  assert.doesNotMatch(robots, /^Disallow: \/$/m);
+});
+
+test("the conventional sitemap URL points agents to Astro's generated child sitemap", async () => {
+  const sitemap = await readPublicFile("sitemap.xml");
+
+  assert.match(sitemap, /<sitemapindex\b/);
+  assert.match(
+    sitemap,
+    /<loc>https:\/\/docs\.dusk\.network\/sitemap-0\.xml<\/loc>/,
+  );
+});
+
+test("documentation pages declare a complete default social preview image", async () => {
+  const config = await readFile(new URL("../astro.config.js", import.meta.url), "utf8");
+
+  assert.match(config, /property: "og:image"/);
+  assert.match(config, /name: "twitter:image"/);
+  assert.match(config, /dusk-social-preview-og\.png/);
+  assert.match(config, /dusk-social-preview-twitter\.png/);
+});

--- a/test/machine-files.test.mjs
+++ b/test/machine-files.test.mjs
@@ -17,14 +17,18 @@ test("robots.txt permits crawling and advertises the generated sitemap index", a
   assert.doesNotMatch(robots, /^Disallow: \/$/m);
 });
 
-test("the conventional sitemap URL points agents to Astro's generated child sitemap", async () => {
-  const sitemap = await readPublicFile("sitemap.xml");
-
-  assert.match(sitemap, /<sitemapindex\b/);
-  assert.match(
-    sitemap,
-    /<loc>https:\/\/docs\.dusk\.network\/sitemap-0\.xml<\/loc>/,
+test("the conventional sitemap URL mirrors Astro's generated sitemap index", async () => {
+  const generatedIndex = await readFile(
+    new URL("../dist/sitemap-index.xml", import.meta.url),
+    "utf8",
   );
+  const conventionalAlias = await readFile(
+    new URL("../dist/sitemap.xml", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(generatedIndex, /<sitemapindex\b/);
+  assert.equal(conventionalAlias, generatedIndex);
 });
 
 test("documentation pages declare a complete default social preview image", async () => {


### PR DESCRIPTION
## Summary

Addresses audit finding **AR-09** and the documentation social-preview gap.

- publishes `/robots.txt` with an allow policy and the real sitemap-index URL
- publishes the conventional `/sitemap.xml` compatibility URL as an exact build-time copy of Astro's generated sitemap index
- adds default Open Graph and Twitter preview images with alt text
- adds repeatable machine-file and metadata tests
- makes CI run the complete verification gate, including the new tests

## Root cause and impact

The documentation sitemap existed at `/sitemap-index.xml`, but the standard `/robots.txt` and `/sitemap.xml` discovery paths returned 404. Agents and crawlers that probe only conventional entry points could therefore miss an otherwise complete sitemap.

The compatibility URL is generated from Astro's actual sitemap index after every build. It cannot silently drift if Astro later splits the sitemap into additional child files or changes their numbering.

## Validation

- clean locked install with lifecycle scripts disabled
- all **362** installed registry packages have verified signatures; **85** have verified attestations
- the approved `esbuild` dependency was explicitly rebuilt
- `npm run verify`: **3 tests passed; 64 pages built**
- Starlight internal-link validation and Pagefind search indexing passed
- local rendered QA passed on desktop, mobile, and JavaScript-disabled documentation pages
- local `/robots.txt`, `/sitemap.xml`, and `/sitemap-index.xml` returned the expected outputs
- the existing Astro `/404` route-conflict warning is unchanged

## Security and remaining risk

This introduces no secrets, write permissions, deployment actions, or publication behavior. The workflow retains read-only repository permissions and does not persist checkout credentials.

The repository's existing dependency audit findings are not introduced by this PR and should be handled separately.

## Deployment and rollback

No content migration is required. Deploy through the normal docs pipeline. Roll back by reverting this PR.

## Post-deployment checks

- verify all three URLs return 200: `/robots.txt`, `/sitemap.xml`, and `/sitemap-index.xml`
- confirm `/sitemap.xml` exactly matches the generated sitemap index
- repeat verified-provider crawler checks against the deployed sitemap index
- inspect a shared docs URL in social-preview debuggers

## Deliberately not included

This PR does not choose product statuses, replace legacy client-side redirect shells, invent page review dates, or synthesize sitemap `lastmod` values. Those require content ownership and/or routing changes.